### PR TITLE
Install package in tox before linters and tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ skip_missing_interpreters = True
 [testenv]
 deps = -r{toxinidir}/requirements.txt
 commands =
+    {envpython} -m pip install .
     flake8 --show-source faster_async_lru
     isort --check-only faster_async_lru --diff
 


### PR DESCRIPTION
### Motivation
- Ensure the project package is installed inside the tox environment so linters and tests exercise the installed (built) package.
- Prevent import/path differences between source checkout and the installed distribution from hiding issues.
- Make linting and test runs consistent with how users will consume the package.

### Description
- Added ` {envpython} -m pip install .` to the `commands` section of `tox.ini` under `[testenv]` so the package is installed before linters and tests run.
- Change is limited to `tox.ini` and runs prior to `flake8`, `isort`, and `pytest` invocations.

### Testing
- No automated tests were executed as part of this change.
- The repository change was committed and prepared as a PR for downstream CI to run tox-based checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ec5caac6c83319e3c0e46c6185a95)