### PR TITLE
Use benchmark requirements for CodSpeed workflow

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -18,7 +18,7 @@ on:
       - compile
     paths:
       - '**.py'
-      - '.github/workflows/codspeed.yaml'
+      - '.github/workflows/codspeed.yml'
       - 'pyproject.toml'
       - 'setup.py'
   workflow_dispatch:

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -39,7 +39,7 @@ jobs:
           cache-dependency-path: '**/requirements*.txt'
 
       - name: Install dependencies
-        run: pip install -r requirements-dev.txt
+        run: pip install -r requirements-benchmarks.txt
 
       - name: Remove python files
         run: rm -r faster_async_lru

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -38,8 +38,8 @@ jobs:
           cache: 'pip'
           cache-dependency-path: '**/requirements*.txt'
 
-      - name: Install dependencies
-        run: pip install -r requirements-benchmarks.txt
+      - name: Install faster async lru
+        run: pip install .[benchmarks]
 
       - name: Remove python files
         run: rm -r faster_async_lru

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -38,8 +38,11 @@ jobs:
           cache: 'pip'
           cache-dependency-path: '**/requirements*.txt'
 
+      - name: Install benchmark requirements
+        run: pip install -r requirements-benchmarks.txt
+        
       - name: Install faster async lru
-        run: pip install .[benchmarks]
+        run: pip install .
 
       - name: Remove python files
         run: rm -r faster_async_lru

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -8,7 +8,7 @@ on:
       - compile
     paths:
       - '**.py'
-      - '.github/workflows/codspeed.yaml'
+      - '.github/workflows/codspeed.yml'
       - 'pyproject.toml'
       - 'setup.py'
   pull_request:

--- a/requirements-benchmarks.txt
+++ b/requirements-benchmarks.txt
@@ -1,4 +1,5 @@
 -e .
 -r requirements-test.txt
 
+async-lru==2.0.5
 pytest-codspeed==4.2.0


### PR DESCRIPTION
### Motivation
- Ensure the CodSpeed GitHub Action installs the benchmark-specific dependencies so `pytest-codspeed` is available.
- Avoid relying on the broader development requirements when running benchmarks by using a focused requirements file.
- Provide a reproducible environment for benchmark instrumentation runs.

### Description
- Change the `Install dependencies` step in `.github/workflows/codspeed.yml` to run `pip install -r requirements-benchmarks.txt` instead of `requirements-dev.txt`.
- The rest of the CodSpeed job steps (checkout, Python setup, uninstall coverage utils, and the benchmark run) remain unchanged.
- Commit and PR were created with the workflow change.

### Testing
- No automated tests were executed because this change only updates a CI workflow file.
- Workflow run was not triggered as part of this change (manual or CI execution may be needed to validate runtime behavior).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964440ce0608331a3c19997d25211d9)