### PR TITLE
test: add regression for asyncio log suppression

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v5
     - name: Setup Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.9
         cache: 'pip'
@@ -69,7 +69,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v5
     - name: Setup Python ${{ matrix.pyver }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         allow-prereleases: true
         python-version: ${{ matrix.pyver }}
@@ -121,7 +121,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v5
     - name: Setup Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.13
     - name: Install dependencies

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 5
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
     - name: Setup Python
       uses: actions/setup-python@v6
       with:
@@ -67,7 +67,7 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
     - name: Setup Python ${{ matrix.pyver }}
       uses: actions/setup-python@v6
       with:
@@ -119,7 +119,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
     - name: Setup Python
       uses: actions/setup-python@v6
       with:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -146,7 +146,7 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
 
     - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v3.1.0
+      uses: sigstore/gh-action-sigstore-python@v3.2.0
       with:
         inputs: >-
           ./dist/*.tar.gz

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -146,7 +146,7 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
 
     - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v3.0.1
+      uses: sigstore/gh-action-sigstore-python@v3.1.0
       with:
         inputs: >-
           ./dist/*.tar.gz

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v6
       with:
-        python-version: 3.9
+        python-version: '3.10'
         cache: 'pip'
         cache-dependency-path: '**/requirements*.txt'
     - name: Pre-Commit hooks
@@ -51,11 +51,11 @@ jobs:
     name: Test
     strategy:
       matrix:
-        pyver: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        pyver: ['3.10', '3.11', '3.12', '3.13', '3.14']
         os: [ubuntu, macos, windows]
         experimental: [false]
         include:
-          - pyver: pypy-3.9
+          - pyver: pypy-3.11
             os: ubuntu
             experimental: false
           - os: ubuntu

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,7 +31,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -45,7 +45,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -58,6 +58,6 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,0 +1,39 @@
+name: CodSpeed Benchmarks
+
+on:
+  push:
+    branches:
+      - master
+      - '[0-9].[0-9]+'
+  pull_request:
+    branches:
+      - master
+      - '[0-9].[0-9]+'
+
+jobs:
+  benchmark:
+    name: Run CodSpeed Benchmarks (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+          cache: 'pip'
+          cache-dependency-path: '**/requirements*.txt'
+
+      - name: Install dependencies
+        run: pip install -r requirements-benchmarks.txt
+
+      - name: Create empty pytest config
+        run: echo "[pytest]" > .empty-pytest.ini
+
+      - name: Run the benchmarks
+        uses: CodSpeedHQ/action@v4
+        with:
+          mode: instrumentation
+          run: pytest -c .empty-pytest.ini --codspeed benchmark.py --timeout=0
+          token: ${{ secrets.CODSPEED_TOKEN }}

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
           cache: 'pip'

--- a/README.rst
+++ b/README.rst
@@ -92,6 +92,32 @@ The library supports explicit invalidation for specific function call by
 The method returns `True` if corresponding arguments set was cached already, `False`
 otherwise.
 
+Benchmarks
+----------
+
+async-lru uses `CodSpeed <https://codspeed.io/>`_ for performance regression testing.
+
+To run the benchmarks locally:
+
+.. code-block:: shell
+
+    pip install -r requirements-dev.txt
+    pytest --codspeed benchmark.py
+
+The benchmark suite covers both bounded (with maxsize) and unbounded (no maxsize) cache configurations. Scenarios include:
+
+- Cache hit
+- Cache miss
+- Cache fill/eviction (cycling through more keys than maxsize)
+- Cache clear
+- TTL expiry
+- Cache invalidation
+- Cache info retrieval
+- Concurrent cache hits
+- Baseline (uncached async function)
+
+On CI, benchmarks are run automatically via GitHub Actions on Python 3.13, and results are uploaded to CodSpeed (if a `CODSPEED_TOKEN` is configured). You can view performance history and detect regressions on the CodSpeed dashboard.
+
 Thanks
 ------
 

--- a/async_lru/__init__.py
+++ b/async_lru/__init__.py
@@ -178,7 +178,10 @@ class _LRUCacheWrapper(Generic[_R]):
         self.__misses += 1
 
     def _task_done_callback(self, key: Hashable, task: "asyncio.Task[_R]") -> None:
-        if task.cancelled() or task.exception() is not None:
+        # We must use the private attribute instead of `exception()`
+        # so asyncio does not set `task.__log_traceback = False` on
+        # the false assumption that the caller read the task Exception
+        if task.cancelled() or task._exception is not None:
             self.__cache.pop(key, None)
             return
 

--- a/benchmark.py
+++ b/benchmark.py
@@ -1,0 +1,313 @@
+import asyncio
+from typing import Any, Callable
+
+import pytest
+
+from async_lru import _LRUCacheWrapper, alru_cache
+
+
+try:
+    from pytest_codspeed import BenchmarkFixture
+except ImportError:  # pragma: no branch  # only hit in cibuildwheel
+    pytestmark = pytest.mark.skip("pytest-codspeed needs to be installed")
+else:
+    pytestmark = pytest.mark.benchmark
+
+
+@pytest.fixture
+def loop():
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    yield loop
+    loop.close()
+
+
+@pytest.fixture
+def run_loop(loop):
+    async def _get_coro(awaitable):
+        """A helper function that turns an awaitable into a coroutine."""
+        return await awaitable
+
+    def run_the_loop(fn, *args, **kwargs):
+        awaitable = fn(*args, **kwargs)
+        coro = awaitable if asyncio.iscoroutine(awaitable) else _get_coro(awaitable)
+        return loop.run_until_complete(coro)
+
+    return run_the_loop
+
+
+# Bounded cache (LRU)
+@alru_cache(maxsize=128)
+async def cached_func(x):
+    return x
+
+
+@alru_cache(maxsize=16, ttl=0.01)
+async def cached_func_ttl(x):
+    return x
+
+
+# Unbounded cache (no maxsize)
+@alru_cache()
+async def cached_func_unbounded(x):
+    return x
+
+
+@alru_cache(ttl=0.01)
+async def cached_func_unbounded_ttl(x):
+    return x
+
+
+class Methods:
+    @alru_cache(maxsize=128)
+    async def cached_meth(self, x):
+        return x
+
+    @alru_cache(maxsize=16, ttl=0.01)
+    async def cached_meth_ttl(self, x):
+        return x
+
+    @alru_cache()
+    async def cached_meth_unbounded(self, x):
+        return x
+
+    @alru_cache(ttl=0.01)
+    async def cached_meth_unbounded_ttl(self, x):
+        return x
+
+
+async def uncached_func(x):
+    return x
+
+
+ids = ["func-bounded", "func-unbounded", "meth-bounded", "meth-unbounded"]
+funcs = [
+    cached_func,
+    cached_func_unbounded,
+    Methods.cached_meth,
+    Methods.cached_meth_unbounded,
+]
+funcs_ttl = [
+    cached_func_ttl,
+    cached_func_unbounded_ttl,
+    Methods.cached_meth_ttl,
+    Methods.cached_meth_unbounded_ttl,
+]
+
+
+@pytest.mark.parametrize("func", funcs, ids=ids)
+def test_cache_hit_benchmark(
+    benchmark: BenchmarkFixture,
+    run_loop: Callable[..., Any],
+    func: _LRUCacheWrapper[Any],
+) -> None:
+    # Populate cache
+    keys = list(range(10))
+    for key in keys:
+        run_loop(func, key)
+
+    async def run() -> None:
+        for _ in range(100):
+            for key in keys:
+                await func(key)
+
+    benchmark(run_loop, run)
+
+
+@pytest.mark.parametrize("func", funcs, ids=ids)
+def test_cache_miss_benchmark(
+    benchmark: BenchmarkFixture,
+    run_loop: Callable[..., Any],
+    func: _LRUCacheWrapper[Any],
+) -> None:
+    unique_objects = [object() for _ in range(128)]
+    func.cache_clear()
+
+    async def run() -> None:
+        for obj in unique_objects:
+            await func(obj)
+
+    benchmark(run_loop, run)
+
+
+@pytest.mark.parametrize("func", funcs, ids=ids)
+def test_cache_clear_benchmark(
+    benchmark: BenchmarkFixture,
+    run_loop: Callable[..., Any],
+    func: _LRUCacheWrapper[Any],
+) -> None:
+    for i in range(100):
+        run_loop(func, i)
+
+    benchmark(func.cache_clear)
+
+
+@pytest.mark.parametrize("func_ttl", funcs_ttl, ids=ids)
+def test_cache_ttl_expiry_benchmark(
+    benchmark: BenchmarkFixture,
+    run_loop: Callable[..., Any],
+    func_ttl: _LRUCacheWrapper[Any],
+) -> None:
+    run_loop(func_ttl, 99)
+    run_loop(asyncio.sleep, 0.02)
+
+    benchmark(run_loop, func_ttl, 99)
+
+
+@pytest.mark.parametrize("func", funcs, ids=ids)
+def test_cache_invalidate_benchmark(
+    benchmark: BenchmarkFixture,
+    run_loop: Callable[..., Any],
+    func: _LRUCacheWrapper[Any],
+) -> None:
+    # Populate cache
+    keys = list(range(123, 321))
+    for i in keys:
+        run_loop(func, i)
+
+    invalidate = func.cache_invalidate
+
+    @benchmark
+    def run() -> None:
+        for i in keys:
+            invalidate(i)
+
+
+@pytest.mark.parametrize("func", funcs, ids=ids)
+def test_cache_info_benchmark(
+    benchmark: BenchmarkFixture,
+    run_loop: Callable[..., Any],
+    func: _LRUCacheWrapper[Any],
+) -> None:
+    # Populate cache
+    keys = list(range(1000))
+    for i in keys:
+        run_loop(func, i)
+
+    cache_info = func.cache_info
+
+    @benchmark
+    def run() -> None:
+        for _ in keys:
+            cache_info()
+
+
+@pytest.mark.parametrize("func", funcs, ids=ids)
+def test_concurrent_cache_hit_benchmark(
+    benchmark: BenchmarkFixture,
+    run_loop: Callable[..., Any],
+    func: _LRUCacheWrapper[Any],
+) -> None:
+    # Populate cache
+    keys = list(range(600, 700))
+    for key in keys:
+        run_loop(func, key)
+
+    async def gather_coros():
+        gather = asyncio.gather
+        for _ in range(10):
+            return await gather(*map(func, keys))
+
+    benchmark(run_loop, gather_coros)
+
+
+def test_cache_fill_eviction_benchmark(
+    benchmark: BenchmarkFixture, run_loop: Callable[..., Any]
+) -> None:
+    # Populate cache
+    for i in range(-128, 0):
+        run_loop(cached_func, i)
+
+    keys = list(range(5000))
+
+    async def fill():
+        for k in keys:
+            await cached_func(k)
+
+    benchmark(run_loop, fill)
+
+
+# ===========================
+# Internal Microbenchmarks
+# ===========================
+# These benchmarks directly exercise internal (sync) methods and data structures
+# not covered by the async public API benchmarks above.
+
+# The relevant internal methods do not exist on _LRUCacheWrapperInstanceMethod,
+# so we can skip methods for this part of the benchmark suite.
+only_funcs = funcs[:2]
+func_ids = ids[:2]
+
+
+@pytest.mark.parametrize("func", only_funcs, ids=func_ids)
+def test_internal_cache_hit_microbenchmark(
+    benchmark: BenchmarkFixture,
+    run_loop: Callable[..., Any],
+    func: _LRUCacheWrapper[Any],
+) -> None:
+    """Directly benchmark _cache_hit (internal, sync) using parameterized funcs."""
+    cache_hit = func._cache_hit
+
+    # Populate cache
+    keys = list(range(128))
+    for i in keys:
+        run_loop(func, i)
+
+    @benchmark
+    def run() -> None:
+        for i in keys:
+            cache_hit(i)
+
+
+@pytest.mark.parametrize("func", only_funcs, ids=func_ids)
+def test_internal_cache_miss_microbenchmark(
+    benchmark: BenchmarkFixture, func: _LRUCacheWrapper[Any]
+) -> None:
+    """Directly benchmark _cache_miss (internal, sync) using parameterized funcs."""
+    cache_miss = func._cache_miss
+
+    @benchmark
+    def run() -> None:
+        for i in range(128):
+            cache_miss(i)
+
+
+@pytest.mark.parametrize("func", only_funcs, ids=func_ids)
+@pytest.mark.parametrize("task_state", ["finished", "cancelled", "exception"])
+def test_internal_task_done_callback_microbenchmark(
+    benchmark: BenchmarkFixture,
+    loop: asyncio.BaseEventLoop,
+    func: _LRUCacheWrapper[Any],
+    task_state: str,
+) -> None:
+    """Directly benchmark _task_done_callback (internal, sync) using parameterized funcs and task states."""
+
+    # Create a dummy coroutine and task
+    async def dummy_coro():
+        if task_state == "exception":
+            raise ValueError("test exception")
+        return 123
+
+    task = loop.create_task(dummy_coro())
+    if task_state == "finished":
+        loop.run_until_complete(task)
+    elif task_state == "cancelled":
+        task.cancel()
+        try:
+            loop.run_until_complete(task)
+        except asyncio.CancelledError:
+            pass
+    elif task_state == "exception":
+        try:
+            loop.run_until_complete(task)
+        except Exception:
+            pass
+
+    iterations = range(1000)
+    create_future = loop.create_future
+    callback = func._task_done_callback
+
+    @benchmark
+    def run() -> None:
+        for i in iterations:
+            callback(create_future(), i, task)

--- a/benchmark.py
+++ b/benchmark.py
@@ -1,4 +1,5 @@
 import asyncio
+from functools import partial
 from typing import Any, Callable
 
 import pytest
@@ -305,9 +306,10 @@ def test_internal_task_done_callback_microbenchmark(
 
     iterations = range(1000)
     create_future = loop.create_future
-    callback = func._task_done_callback
+    callback_fn = func._task_done_callback
 
     @benchmark
     def run() -> None:
         for i in iterations:
-            callback(create_future(), i, task)
+            callback = partial(callback_fn, create_future(), i)
+            callback(task)

--- a/benchmark.py
+++ b/benchmark.py
@@ -81,22 +81,37 @@ async def uncached_func(x):
     return x
 
 
-ids = ["func-bounded", "func-unbounded", "meth-bounded", "meth-unbounded"]
-funcs = [
+funcs_no_ttl = [
     cached_func,
     cached_func_unbounded,
     Methods.cached_meth,
     Methods.cached_meth_unbounded,
 ]
+no_ttl_ids = [
+    "func-bounded",
+    "func-unbounded",
+    "meth-bounded",
+    "meth-unbounded",
+]
+
 funcs_ttl = [
     cached_func_ttl,
     cached_func_unbounded_ttl,
     Methods.cached_meth_ttl,
     Methods.cached_meth_unbounded_ttl,
 ]
+ttl_ids = [
+    "func-bounded-ttl",
+    "func-unbounded-ttl",
+    "meth-bounded-ttl",
+    "meth-unbounded-ttl",
+]
+
+all_funcs = [*funcs_no_ttl, *funcs_ttl]
+all_ids = [*no_ttl_ids, *ttl_ids]
 
 
-@pytest.mark.parametrize("func", funcs, ids=ids)
+@pytest.mark.parametrize("func", all_funcs, ids=all_ids)
 def test_cache_hit_benchmark(
     benchmark: BenchmarkFixture,
     run_loop: Callable[..., Any],
@@ -115,7 +130,7 @@ def test_cache_hit_benchmark(
     benchmark(run_loop, run)
 
 
-@pytest.mark.parametrize("func", funcs, ids=ids)
+@pytest.mark.parametrize("func", all_funcs, ids=all_ids)
 def test_cache_miss_benchmark(
     benchmark: BenchmarkFixture,
     run_loop: Callable[..., Any],
@@ -131,7 +146,7 @@ def test_cache_miss_benchmark(
     benchmark(run_loop, run)
 
 
-@pytest.mark.parametrize("func", funcs, ids=ids)
+@pytest.mark.parametrize("func", all_funcs, ids=all_ids)
 def test_cache_clear_benchmark(
     benchmark: BenchmarkFixture,
     run_loop: Callable[..., Any],
@@ -143,7 +158,7 @@ def test_cache_clear_benchmark(
     benchmark(func.cache_clear)
 
 
-@pytest.mark.parametrize("func_ttl", funcs_ttl, ids=ids)
+@pytest.mark.parametrize("func_ttl", funcs_ttl, ids=ttl_ids)
 def test_cache_ttl_expiry_benchmark(
     benchmark: BenchmarkFixture,
     run_loop: Callable[..., Any],
@@ -155,7 +170,7 @@ def test_cache_ttl_expiry_benchmark(
     benchmark(run_loop, func_ttl, 99)
 
 
-@pytest.mark.parametrize("func", funcs, ids=ids)
+@pytest.mark.parametrize("func", all_funcs, ids=all_ids)
 def test_cache_invalidate_benchmark(
     benchmark: BenchmarkFixture,
     run_loop: Callable[..., Any],
@@ -174,7 +189,7 @@ def test_cache_invalidate_benchmark(
             invalidate(i)
 
 
-@pytest.mark.parametrize("func", funcs, ids=ids)
+@pytest.mark.parametrize("func", all_funcs, ids=all_ids)
 def test_cache_info_benchmark(
     benchmark: BenchmarkFixture,
     run_loop: Callable[..., Any],
@@ -193,7 +208,7 @@ def test_cache_info_benchmark(
             cache_info()
 
 
-@pytest.mark.parametrize("func", funcs, ids=ids)
+@pytest.mark.parametrize("func", all_funcs, ids=all_ids)
 def test_concurrent_cache_hit_benchmark(
     benchmark: BenchmarkFixture,
     run_loop: Callable[..., Any],
@@ -236,11 +251,12 @@ def test_cache_fill_eviction_benchmark(
 
 # The relevant internal methods do not exist on _LRUCacheWrapperInstanceMethod,
 # so we can skip methods for this part of the benchmark suite.
-only_funcs = funcs[:2]
-func_ids = ids[:2]
+# We also skip wrappers with ttl because it raises KeyError.
+only_funcs_no_ttl = all_funcs[:2]
+func_ids_no_ttl = all_ids[:2]
 
 
-@pytest.mark.parametrize("func", only_funcs, ids=func_ids)
+@pytest.mark.parametrize("func", only_funcs_no_ttl, ids=func_ids_no_ttl)
 def test_internal_cache_hit_microbenchmark(
     benchmark: BenchmarkFixture,
     run_loop: Callable[..., Any],
@@ -260,7 +276,7 @@ def test_internal_cache_hit_microbenchmark(
             cache_hit(i)
 
 
-@pytest.mark.parametrize("func", only_funcs, ids=func_ids)
+@pytest.mark.parametrize("func", only_funcs_no_ttl, ids=func_ids_no_ttl)
 def test_internal_cache_miss_microbenchmark(
     benchmark: BenchmarkFixture, func: _LRUCacheWrapper[Any]
 ) -> None:
@@ -273,7 +289,7 @@ def test_internal_cache_miss_microbenchmark(
             cache_miss(i)
 
 
-@pytest.mark.parametrize("func", only_funcs, ids=func_ids)
+@pytest.mark.parametrize("func", only_funcs_no_ttl, ids=func_ids_no_ttl)
 @pytest.mark.parametrize("task_state", ["finished", "cancelled", "exception"])
 def test_internal_task_done_callback_microbenchmark(
     benchmark: BenchmarkFixture,

--- a/benchmark.py
+++ b/benchmark.py
@@ -321,11 +321,10 @@ def test_internal_task_done_callback_microbenchmark(
             pass
 
     iterations = range(1000)
-    create_future = loop.create_future
     callback_fn = func._task_done_callback
 
     @benchmark
     def run() -> None:
         for i in iterations:
-            callback = partial(callback_fn, create_future(), i)
+            callback = partial(callback_fn, i)
             callback(task)

--- a/requirements-benchmarks.txt
+++ b/requirements-benchmarks.txt
@@ -1,0 +1,4 @@
+-e .
+-r requirements-test.txt
+
+pytest-codspeed==4.0.0

--- a/requirements-benchmarks.txt
+++ b/requirements-benchmarks.txt
@@ -1,4 +1,4 @@
 -e .
 -r requirements-test.txt
 
-pytest-codspeed==4.1.1
+pytest-codspeed==4.2.0

--- a/requirements-benchmarks.txt
+++ b/requirements-benchmarks.txt
@@ -1,4 +1,4 @@
 -e .
 -r requirements-test.txt
 
-pytest-codspeed==4.0.0
+pytest-codspeed==4.1.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,4 +5,4 @@ flake8-bandit==4.1.1
 flake8-bugbear==25.11.29
 flake8-import-order==0.19.2
 flake8-requirements==2.3.0
-mypy==1.19.0; implementation_name=="cpython"
+mypy==1.19.1; implementation_name=="cpython"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 
 flake8==7.3.0
 flake8-bandit==4.1.1
-flake8-bugbear==25.10.21
+flake8-bugbear==25.11.29
 flake8-import-order==0.19.2
 flake8-requirements==2.3.0
 mypy==1.18.2; implementation_name=="cpython"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 
 flake8==7.3.0
 flake8-bandit==4.1.1
-flake8-bugbear==24.12.12
+flake8-bugbear==25.10.21
 flake8-import-order==0.19.2
 flake8-requirements==2.3.0
 mypy==1.18.2; implementation_name=="cpython"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,4 +5,4 @@ flake8-bandit==4.1.1
 flake8-bugbear==25.11.29
 flake8-import-order==0.19.2
 flake8-requirements==2.3.0
-mypy==1.18.2; implementation_name=="cpython"
+mypy==1.19.0; implementation_name=="cpython"

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,3 @@
-pytest==9.0.1
+pytest==9.0.2
 pytest-asyncio==1.3.0
 pytest-timeout==2.4.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,3 @@
+pytest==8.4.2
+pytest-asyncio==1.2.0
+pytest-timeout==2.4.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,3 @@
 pytest==8.4.2
-pytest-asyncio==1.2.0
+pytest-asyncio==1.3.0
 pytest-timeout==2.4.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,3 @@
-pytest==8.4.2
+pytest==9.0.1
 pytest-asyncio==1.3.0
 pytest-timeout==2.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 -e .
 -r requirements-test.txt
 
-coverage==7.12.0
+coverage==7.13.0
 pytest-cov==7.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 -e .
 -r requirements-test.txt
 
-coverage==7.13.0
+coverage==7.13.1
 pytest-cov==7.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 -e .
 
-coverage==7.10.6
+coverage==7.10.7
 pytest==8.4.2
 pytest-asyncio==1.2.0
 pytest-cov==7.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 -e .
+-r requirements-test.txt
 
 coverage==7.10.7
-pytest==8.4.2
-pytest-asyncio==1.2.0
 pytest-cov==7.0.0
-pytest-timeout==2.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 -e .
 -r requirements-test.txt
 
-coverage==7.10.7
+coverage==7.12.0
 pytest-cov==7.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,11 +23,11 @@ classifiers =
   Programming Language :: Python
   Programming Language :: Python :: 3
   Programming Language :: Python :: 3 :: Only
-  Programming Language :: Python :: 3.9
   Programming Language :: Python :: 3.10
   Programming Language :: Python :: 3.11
   Programming Language :: Python :: 3.12
   Programming Language :: Python :: 3.13
+  Programming Language :: Python :: 3.14
 
   Development Status :: 5 - Production/Stable
 
@@ -39,7 +39,7 @@ keywords =
   lru_cache
 
 [options]
-python_requires = >=3.9
+python_requires = >=3.10
 packages = find:
 
 install_requires =

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -152,8 +152,8 @@ async def test_alru_cache_dict_not_shared(check_lru: Callable[..., None]) -> Non
     assert ret1 == ret2
 
     assert (
-        coro1._LRUCacheWrapper__cache[1].fut.result()  # type: ignore[attr-defined]
-        == coro2._LRUCacheWrapper__cache[1].fut.result()  # type: ignore[attr-defined]
+        coro1._LRUCacheWrapper__cache[1].task.result()  # type: ignore[attr-defined]
+        == coro2._LRUCacheWrapper__cache[1].task.result()  # type: ignore[attr-defined]
     )
     assert coro1._LRUCacheWrapper__cache != coro2._LRUCacheWrapper__cache  # type: ignore[attr-defined]
     assert coro1._LRUCacheWrapper__cache.keys() == coro2._LRUCacheWrapper__cache.keys()  # type: ignore[attr-defined]

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,6 +1,5 @@
 import asyncio
 import inspect
-import platform
 import sys
 from functools import _CacheInfo, partial
 from typing import Callable
@@ -200,10 +199,6 @@ async def test_alru_cache_method() -> None:
     )
 
 
-@pytest.mark.xfail(
-    sys.version_info[:2] == (3, 9) and platform.python_implementation() != "PyPy",
-    reason="#511",
-)
 async def test_alru_cache_classmethod() -> None:
     class A:
         offset = 3

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -1,0 +1,58 @@
+import asyncio
+
+import pytest
+
+from async_lru import alru_cache
+
+
+@pytest.mark.parametrize("num_to_cancel", (0, 1, 2, 3))
+async def test_cancel(num_to_cancel: int) -> None:
+    @alru_cache
+    async def coro(val: int) -> int:
+        # I am a long running coro function
+        await asyncio.sleep(0.1)
+        return val
+
+    # create 3 tasks for the cached function using the same key
+    tasks = [asyncio.create_task(coro(i)) for i in range(3)]
+
+    # force the event loop to run once so the tasks can begin
+    await asyncio.sleep(0)
+
+    # maybe cancel some tasks
+    for i in range(num_to_cancel):
+        tasks[i].cancel()
+
+    # allow enough time for the non-cancelled tasks to complete
+    await asyncio.sleep(0.2)
+
+    # check tasks are properly cancelled
+    for i in range(num_to_cancel):
+        assert tasks[i].cancelled()
+
+    # check non-cancelled tasks return expected outputs
+    for i in range(num_to_cancel, 3):
+        assert await tasks[i] == i
+
+
+@pytest.mark.asyncio
+async def test_cancel_single_waiter_triggers_handle_cancelled_error() -> None:
+    # This test ensures the _handle_cancelled_error path (waiters == 1) is exercised.
+    cache_item_task_finished = False
+
+    @alru_cache
+    async def coro(val: int) -> None:
+        nonlocal cache_item_task_finished
+        await asyncio.sleep(2)
+        cache_item_task_finished = True  # pragma: no cover
+
+    task = asyncio.create_task(coro(42))
+    await asyncio.sleep(0)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+    # The underlying coroutine should be cancelled, so the flag should remain False
+    assert cache_item_task_finished is False

--- a/tests/test_exception.py
+++ b/tests/test_exception.py
@@ -30,7 +30,7 @@ async def test_alru_exception(check_lru: Callable[..., None]) -> None:
 
 
 @pytest.mark.xfail(
-    reason="Memory leak is not fixed for PyPy3.9",
+    reason="Memory leak is not fixed for PyPy",
     condition=sys.implementation.name == "pypy",
 )
 async def test_alru_exception_reference_cleanup(check_lru: Callable[..., None]) -> None:

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -11,30 +11,26 @@ async def test_done_callback_cancelled() -> None:
     wrapped = _LRUCacheWrapper(mock.ANY, None, False, None)
     loop = asyncio.get_running_loop()
     task = loop.create_future()
-    fut = loop.create_future()
 
     key = 1
 
-    task.add_done_callback(partial(wrapped._task_done_callback, fut, key))
-    wrapped._LRUCacheWrapper__tasks.add(task)  # type: ignore[attr-defined]
+    task.add_done_callback(partial(wrapped._task_done_callback, key))
 
     task.cancel()
 
     await asyncio.sleep(0)
 
-    assert fut.cancelled()
+    assert task not in wrapped._LRUCacheWrapper__tasks  # type: ignore[attr-defined]
 
 
 async def test_done_callback_exception() -> None:
     wrapped = _LRUCacheWrapper(mock.ANY, None, False, None)
     loop = asyncio.get_running_loop()
     task = loop.create_future()
-    fut = loop.create_future()
 
     key = 1
 
-    task.add_done_callback(partial(wrapped._task_done_callback, fut, key))
-    wrapped._LRUCacheWrapper__tasks.add(task)  # type: ignore[attr-defined]
+    task.add_done_callback(partial(wrapped._task_done_callback, key))
 
     exc = ZeroDivisionError()
 
@@ -42,31 +38,7 @@ async def test_done_callback_exception() -> None:
 
     await asyncio.sleep(0)
 
-    with pytest.raises(ZeroDivisionError):
-        await fut
-
-    with pytest.raises(ZeroDivisionError):
-        fut.result()
-
-    assert fut.exception() is exc
-
-
-async def test_done_callback() -> None:
-    wrapped = _LRUCacheWrapper(mock.ANY, None, False, None)
-    loop = asyncio.get_running_loop()
-    task = loop.create_future()
-
-    key = 1
-    fut = loop.create_future()
-
-    task.add_done_callback(partial(wrapped._task_done_callback, fut, key))
-    wrapped._LRUCacheWrapper__tasks.add(task)  # type: ignore[attr-defined]
-
-    task.set_result(1)
-
-    await asyncio.sleep(0)
-
-    assert fut.result() == 1
+    assert task not in wrapped._LRUCacheWrapper__tasks  # type: ignore[attr-defined]
 
 
 async def test_cache_invalidate_typed() -> None:

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -1,10 +1,12 @@
 import asyncio
+import gc
+import logging
 from functools import partial
 from unittest import mock
 
 import pytest
 
-from async_lru import _LRUCacheWrapper
+from async_lru import _CacheItem, _LRUCacheWrapper
 
 
 async def test_done_callback_cancelled() -> None:
@@ -39,6 +41,34 @@ async def test_done_callback_exception() -> None:
     await asyncio.sleep(0)
 
     assert task not in wrapped._LRUCacheWrapper__tasks  # type: ignore[attr-defined]
+
+
+async def test_done_callback_exception_logs(caplog: pytest.LogCaptureFixture) -> None:
+    wrapped = _LRUCacheWrapper(mock.ANY, None, False, None)
+    loop = asyncio.get_running_loop()
+
+    async def boom() -> None:
+        await asyncio.sleep(0)
+        raise RuntimeError("boom")
+
+    key = object()
+    task = loop.create_task(boom())
+    wrapped._LRUCacheWrapper__cache[key] = _CacheItem(task, None, 1)  # type: ignore[attr-defined]
+    task.add_done_callback(partial(wrapped._task_done_callback, key))
+
+    await asyncio.sleep(0)
+
+    assert key not in wrapped._LRUCacheWrapper__cache  # type: ignore[attr-defined]
+
+    caplog.set_level(logging.ERROR, logger="asyncio")
+    caplog.clear()
+
+    task = None
+    gc.collect()
+    await asyncio.sleep(0)
+
+    assert "Task exception was never retrieved" in caplog.text
+    assert "RuntimeError: boom" in caplog.text
 
 
 async def test_cache_invalidate_typed() -> None:


### PR DESCRIPTION
## What do these changes do?
Add a regression test that verifies `_task_done_callback` does not suppress asyncio's "Task exception was never retrieved" logging. The test runs the task on a dedicated loop, confirms the cache entry is cleared, and asserts the task remains loggable before GC.

## Are there changes in behavior for the user?
No.

## Related issue number
N/A

## Checklist
- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
