### PR TITLE
test: add asyncio log regression coverage

### DIFF
--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -1,7 +1,5 @@
 import asyncio
-import gc
 import logging
-import weakref
 from functools import partial
 from unittest import mock
 
@@ -56,7 +54,6 @@ async def test_done_callback_exception_logs(caplog: pytest.LogCaptureFixture) ->
 
     key = object()
     task = loop.create_task(boom())
-    task_ref = weakref.ref(task)
     wrapped._LRUCacheWrapper__cache[key] = _CacheItem(task, None, 1)  # type: ignore[attr-defined]
     task.add_done_callback(partial(wrapped._task_done_callback, key))
 
@@ -65,16 +62,8 @@ async def test_done_callback_exception_logs(caplog: pytest.LogCaptureFixture) ->
     await asyncio.sleep(0)
 
     assert key not in wrapped._LRUCacheWrapper__cache  # type: ignore[attr-defined]
-
-    caplog.clear()
-
-    task = None
-    gc.collect()
-    await asyncio.sleep(0)
-
-    assert task_ref() is None
-    assert "Task exception was never retrieved" in caplog.text
-    assert "RuntimeError: boom" in caplog.text
+    # asyncio disables logging when exception() is called; keep logging enabled.
+    assert task._log_traceback  # type: ignore[attr-defined]
 
 
 async def test_cache_invalidate_typed() -> None:

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -1,4 +1,5 @@
 import asyncio
+import gc
 import logging
 from functools import partial
 from unittest import mock
@@ -64,6 +65,18 @@ async def test_done_callback_exception_logs(caplog: pytest.LogCaptureFixture) ->
     assert key not in wrapped._LRUCacheWrapper__cache  # type: ignore[attr-defined]
     # asyncio disables logging when exception() is called; keep logging enabled.
     assert task._log_traceback  # type: ignore[attr-defined]
+
+    caplog.clear()
+
+    task = None
+    for _ in range(5):
+        gc.collect()
+        await asyncio.sleep(0)
+        if "Task exception was never retrieved" in caplog.text:
+            break
+
+    assert "Task exception was never retrieved" in caplog.text
+    assert "RuntimeError: boom" in caplog.text
 
 
 async def test_cache_invalidate_typed() -> None:

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -1,10 +1,13 @@
 import asyncio
+import gc
+import logging
+import weakref
 from functools import partial
 from unittest import mock
 
 import pytest
 
-from async_lru import _LRUCacheWrapper
+from async_lru import _CacheItem, _LRUCacheWrapper
 
 
 async def test_done_callback_cancelled() -> None:
@@ -39,6 +42,39 @@ async def test_done_callback_exception() -> None:
     await asyncio.sleep(0)
 
     assert task not in wrapped._LRUCacheWrapper__tasks  # type: ignore[attr-defined]
+
+
+async def test_done_callback_exception_logs(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.ERROR, logger="asyncio")
+
+    wrapped = _LRUCacheWrapper(mock.ANY, None, False, None)
+    loop = asyncio.get_running_loop()
+
+    async def boom() -> None:
+        await asyncio.sleep(0)
+        raise RuntimeError("boom")
+
+    key = object()
+    task = loop.create_task(boom())
+    task_ref = weakref.ref(task)
+    wrapped._LRUCacheWrapper__cache[key] = _CacheItem(task, None, 1)  # type: ignore[attr-defined]
+    task.add_done_callback(partial(wrapped._task_done_callback, key))
+
+    while not task.done():
+        await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert key not in wrapped._LRUCacheWrapper__cache  # type: ignore[attr-defined]
+
+    caplog.clear()
+
+    task = None
+    gc.collect()
+    await asyncio.sleep(0)
+
+    assert task_ref() is None
+    assert "Task exception was never retrieved" in caplog.text
+    assert "RuntimeError: boom" in caplog.text
 
 
 async def test_cache_invalidate_typed() -> None:


### PR DESCRIPTION
## What do these changes do?
Add a regression test that verifies `_task_done_callback` does not suppress asyncio's "Task exception was never retrieved" logging. The test waits for the task to finish, clears strong refs, and asserts the log output.

## Are there changes in behavior for the user?
No.

## Related issue number
N/A

## Checklist
- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
