### PR TITLE
feat: ALLOW_SYNC constant for env override

### DIFF
--- a/build/__native.c
+++ b/build/__native.c
@@ -3094,6 +3094,8 @@ int CPyExec_faster_async_lru(PyObject *module)
     fail:
     Py_CLEAR(CPyModule_faster_async_lru__internal);
     Py_CLEAR(modname);
+    CPy_XDECREF(CPyStatic_ALLOW_SYNC);
+    CPyStatic_ALLOW_SYNC = NULL;
     CPyStatic__PYTHON_GTE_312 = 2;
     CPyStatic__PYTHON_LT_314 = 2;
     CPy_XDECREF(CPyStatic_CancelledError);
@@ -3236,7 +3238,7 @@ char CPyDef__CacheItem___cancel(PyObject *cpy_r_self) {
     char cpy_r_r12;
     cpy_r_r0 = ((faster_async_lru____CacheItemObject *)cpy_r_self)->_later_call;
     if (unlikely(cpy_r_r0 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "cancel", "_CacheItem", "later_call", 77, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "cancel", "_CacheItem", "later_call", 80, CPyStatic_globals);
         goto CPyL8;
     }
 CPyL1: ;
@@ -3245,7 +3247,7 @@ CPyL1: ;
     if (!cpy_r_r2) goto CPyL7;
     cpy_r_r3 = ((faster_async_lru____CacheItemObject *)cpy_r_self)->_later_call;
     if (unlikely(cpy_r_r3 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "cancel", "_CacheItem", "later_call", 78, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "cancel", "_CacheItem", "later_call", 81, CPyStatic_globals);
         goto CPyL8;
     }
     CPy_INCREF(cpy_r_r3);
@@ -3412,7 +3414,7 @@ char CPyDef__LRUCacheWrapper_____init__(PyObject *cpy_r_self, PyObject *cpy_r_fn
     if (likely(PyUnicode_Check(cpy_r_r1)))
         cpy_r_r2 = cpy_r_r1;
     else {
-        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "__init__", 92, CPyStatic_globals, "str", cpy_r_r1);
+        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "__init__", 95, CPyStatic_globals, "str", cpy_r_r1);
         goto CPyL4;
     }
     if (((faster_async_lru____LRUCacheWrapperObject *)cpy_r_self)->___module__ != NULL) {
@@ -3466,7 +3468,7 @@ CPyL11: ;
     if (likely(PyUnicode_Check(cpy_r_r10)))
         cpy_r_r11 = cpy_r_r10;
     else {
-        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "__init__", 96, CPyStatic_globals, "str", cpy_r_r10);
+        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "__init__", 99, CPyStatic_globals, "str", cpy_r_r10);
         goto CPyL14;
     }
     if (((faster_async_lru____LRUCacheWrapperObject *)cpy_r_self)->___name__ != NULL) {
@@ -3521,7 +3523,7 @@ CPyL21: ;
     if (likely(PyUnicode_Check(cpy_r_r20)))
         cpy_r_r21 = cpy_r_r20;
     else {
-        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "__init__", 100, CPyStatic_globals, "str", cpy_r_r20);
+        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "__init__", 103, CPyStatic_globals, "str", cpy_r_r20);
         goto CPyL24;
     }
     if (((faster_async_lru____LRUCacheWrapperObject *)cpy_r_self)->___qualname__ != NULL) {
@@ -3585,7 +3587,7 @@ CPyL31: ;
         cpy_r_r31 = NULL;
     }
     if (cpy_r_r31 != NULL) goto __LL6;
-    CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "__init__", 104, CPyStatic_globals, "str or None", cpy_r_r30);
+    CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "__init__", 107, CPyStatic_globals, "str or None", cpy_r_r30);
     goto CPyL34;
 __LL6: ;
     if (((faster_async_lru____LRUCacheWrapperObject *)cpy_r_self)->___doc__ != NULL) {
@@ -3640,7 +3642,7 @@ CPyL41: ;
     if (likely(PyDict_Check(cpy_r_r40)))
         cpy_r_r41 = cpy_r_r40;
     else {
-        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "__init__", 108, CPyStatic_globals, "dict", cpy_r_r40);
+        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "__init__", 111, CPyStatic_globals, "dict", cpy_r_r40);
         goto CPyL44;
     }
     if (((faster_async_lru____LRUCacheWrapperObject *)cpy_r_self)->___annotations__ != NULL) {
@@ -3695,7 +3697,7 @@ CPyL51: ;
     if (likely(PyDict_Check(cpy_r_r50)))
         cpy_r_r51 = cpy_r_r50;
     else {
-        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "__init__", 112, CPyStatic_globals, "dict", cpy_r_r50);
+        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "__init__", 115, CPyStatic_globals, "dict", cpy_r_r50);
         goto CPyL56;
     }
     cpy_r_r52 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__dict__' */
@@ -3707,7 +3709,7 @@ CPyL51: ;
     if (likely(PyDict_Check(cpy_r_r53)))
         cpy_r_r54 = cpy_r_r53;
     else {
-        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "__init__", 112, CPyStatic_globals, "dict", cpy_r_r53);
+        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "__init__", 115, CPyStatic_globals, "dict", cpy_r_r53);
         goto CPyL88;
     }
     cpy_r_r55 = CPyDict_Update(cpy_r_r51, cpy_r_r54);
@@ -3848,7 +3850,7 @@ CPyL70: ;
     if (likely(PyDict_Check(cpy_r_r80)))
         cpy_r_r81 = cpy_r_r80;
     else {
-        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "__init__", 123, CPyStatic_globals, "dict", cpy_r_r80);
+        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "__init__", 126, CPyStatic_globals, "dict", cpy_r_r80);
         goto CPyL82;
     }
     if (((faster_async_lru____LRUCacheWrapperObject *)cpy_r_self)->___cache != NULL) {
@@ -4024,7 +4026,7 @@ PyObject *CPyDef__LRUCacheWrapper_____tasks(PyObject *cpy_r_self) {
     }
     cpy_r_r1 = ((faster_async_lru____LRUCacheWrapperObject *)cpy_r_self)->___cache;
     if (unlikely(cpy_r_r1 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__tasks", "_LRUCacheWrapper", "__cache", 134, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__tasks", "_LRUCacheWrapper", "__cache", 137, CPyStatic_globals);
         goto CPyL16;
     }
     CPy_INCREF(cpy_r_r1);
@@ -4048,12 +4050,12 @@ CPyL3: ;
     if (likely(Py_TYPE(cpy_r_r8) == CPyType__CacheItem))
         cpy_r_r9 = cpy_r_r8;
     else {
-        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "__tasks", 132, CPyStatic_globals, "faster_async_lru._CacheItem", cpy_r_r8);
+        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "__tasks", 135, CPyStatic_globals, "faster_async_lru._CacheItem", cpy_r_r8);
         goto CPyL19;
     }
     cpy_r_r10 = ((faster_async_lru____CacheItemObject *)cpy_r_r9)->_task;
     if (unlikely(cpy_r_r10 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__tasks", "_CacheItem", "task", 135, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__tasks", "_CacheItem", "task", 138, CPyStatic_globals);
         goto CPyL20;
     }
     CPy_INCREF(cpy_r_r10);
@@ -4192,7 +4194,7 @@ char CPyDef__LRUCacheWrapper___cache_invalidate(PyObject *cpy_r_self, PyObject *
     char cpy_r_r13;
     cpy_r_r0 = ((faster_async_lru____LRUCacheWrapperObject *)cpy_r_self)->___typed;
     if (unlikely(cpy_r_r0 == 2)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "cache_invalidate", "_LRUCacheWrapper", "__typed", 140, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "cache_invalidate", "_LRUCacheWrapper", "__typed", 143, CPyStatic_globals);
         goto CPyL10;
     }
 CPyL1: ;
@@ -4203,7 +4205,7 @@ CPyL1: ;
     }
     cpy_r_r2 = ((faster_async_lru____LRUCacheWrapperObject *)cpy_r_self)->___cache;
     if (unlikely(cpy_r_r2 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "cache_invalidate", "_LRUCacheWrapper", "__cache", 142, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "cache_invalidate", "_LRUCacheWrapper", "__cache", 145, CPyStatic_globals);
         goto CPyL11;
     }
     CPy_INCREF(cpy_r_r2);
@@ -4231,7 +4233,7 @@ CPyL3: ;
         cpy_r_r8 = NULL;
     }
     if (cpy_r_r8 != NULL) goto __LL11;
-    CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "cache_invalidate", 142, CPyStatic_globals, "faster_async_lru._CacheItem or None", cpy_r_r7);
+    CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "cache_invalidate", 145, CPyStatic_globals, "faster_async_lru._CacheItem or None", cpy_r_r7);
     goto CPyL10;
 __LL11: ;
     cpy_r_r9 = (PyObject *)&_Py_NoneStruct;
@@ -4246,7 +4248,7 @@ CPyL7: ;
     if (likely(cpy_r_r8 != Py_None))
         cpy_r_r11 = cpy_r_r8;
     else {
-        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "cache_invalidate", 146, CPyStatic_globals, "faster_async_lru._CacheItem", cpy_r_r8);
+        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "cache_invalidate", 149, CPyStatic_globals, "faster_async_lru._CacheItem", cpy_r_r8);
         goto CPyL10;
     }
     cpy_r_r12 = CPyDef__CacheItem___cancel(cpy_r_r11);
@@ -4355,7 +4357,7 @@ char CPyDef__LRUCacheWrapper___cache_clear(PyObject *cpy_r_self) {
     }
     cpy_r_r2 = ((faster_async_lru____LRUCacheWrapperObject *)cpy_r_self)->___cache;
     if (unlikely(cpy_r_r2 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "cache_clear", "_LRUCacheWrapper", "__cache", 153, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "cache_clear", "_LRUCacheWrapper", "__cache", 156, CPyStatic_globals);
         goto CPyL20;
     }
     CPy_INCREF(cpy_r_r2);
@@ -4379,12 +4381,12 @@ CPyL4: ;
     if (likely(Py_TYPE(cpy_r_r9) == CPyType__CacheItem))
         cpy_r_r10 = cpy_r_r9;
     else {
-        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "cache_clear", 153, CPyStatic_globals, "faster_async_lru._CacheItem", cpy_r_r9);
+        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "cache_clear", 156, CPyStatic_globals, "faster_async_lru._CacheItem", cpy_r_r9);
         goto CPyL23;
     }
     cpy_r_r11 = ((faster_async_lru____CacheItemObject *)cpy_r_r10)->_later_call;
     if (unlikely(cpy_r_r11 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "cache_clear", "_CacheItem", "later_call", 154, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "cache_clear", "_CacheItem", "later_call", 157, CPyStatic_globals);
         goto CPyL24;
     }
     CPy_INCREF(cpy_r_r11);
@@ -4448,7 +4450,7 @@ CPyL16: ;
     }
     cpy_r_r27 = ((faster_async_lru____LRUCacheWrapperObject *)cpy_r_self)->___cache;
     if (unlikely(cpy_r_r27 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "cache_clear", "_LRUCacheWrapper", "__cache", 156, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "cache_clear", "_LRUCacheWrapper", "__cache", 159, CPyStatic_globals);
         goto CPyL20;
     }
     CPy_INCREF(cpy_r_r27);
@@ -4624,7 +4626,7 @@ CPyL1: ;
 CPyL4: ;
     cpy_r_r5 = ((faster_async_lru___cache_close__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__self;
     if (unlikely(cpy_r_r5 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "cache_close", "cache_close__LRUCacheWrapper_gen", "self", 159, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "cache_close", "cache_close__LRUCacheWrapper_gen", "self", 162, CPyStatic_globals);
         goto CPyL82;
     }
     CPy_INCREF_NO_IMM(cpy_r_r5);
@@ -4638,7 +4640,7 @@ CPyL5: ;
     }
     cpy_r_r7 = ((faster_async_lru___cache_close__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__self;
     if (unlikely(cpy_r_r7 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "cache_close", "cache_close__LRUCacheWrapper_gen", "self", 161, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "cache_close", "cache_close__LRUCacheWrapper_gen", "self", 164, CPyStatic_globals);
         goto CPyL82;
     }
     CPy_INCREF_NO_IMM(cpy_r_r7);
@@ -4661,7 +4663,7 @@ CPyL8: ;
     }
     cpy_r_r10 = ((faster_async_lru___cache_close__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__tasks;
     if (unlikely(cpy_r_r10 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "cache_close", "cache_close__LRUCacheWrapper_gen", "tasks", 162, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "cache_close", "cache_close__LRUCacheWrapper_gen", "tasks", 165, CPyStatic_globals);
         goto CPyL82;
     }
     CPy_INCREF_NO_IMM(cpy_r_r10);
@@ -4684,7 +4686,7 @@ CPyL15: ;
 CPyL16: ;
     cpy_r_r17 = ((faster_async_lru___cache_close__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__wait;
     if (unlikely(cpy_r_r17 == 2)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "cache_close", "cache_close__LRUCacheWrapper_gen", "wait", 165, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "cache_close", "cache_close__LRUCacheWrapper_gen", "wait", 168, CPyStatic_globals);
         goto CPyL82;
     }
 CPyL17: ;
@@ -4692,7 +4694,7 @@ CPyL17: ;
 CPyL18: ;
     cpy_r_r18 = ((faster_async_lru___cache_close__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__tasks;
     if (unlikely(cpy_r_r18 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "cache_close", "cache_close__LRUCacheWrapper_gen", "tasks", 166, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "cache_close", "cache_close__LRUCacheWrapper_gen", "tasks", 169, CPyStatic_globals);
         goto CPyL82;
     }
     CPy_INCREF_NO_IMM(cpy_r_r18);
@@ -4715,7 +4717,7 @@ CPyL19: ;
 CPyL21: ;
     cpy_r_r21 = ((faster_async_lru___cache_close__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_temp__0;
     if (unlikely(cpy_r_r21 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "cache_close", "cache_close__LRUCacheWrapper_gen", "__mypyc_temp__0", 166, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "cache_close", "cache_close__LRUCacheWrapper_gen", "__mypyc_temp__0", 169, CPyStatic_globals);
         goto CPyL82;
     }
     CPy_INCREF_NO_IMM(cpy_r_r21);
@@ -4725,7 +4727,7 @@ CPyL22: ;
     CPy_DECREF_NO_IMM(cpy_r_r21);
     cpy_r_r24 = ((faster_async_lru___cache_close__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_temp__1;
     if (unlikely(cpy_r_r24 == -113)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "cache_close", "cache_close__LRUCacheWrapper_gen", "__mypyc_temp__1", 166, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "cache_close", "cache_close__LRUCacheWrapper_gen", "__mypyc_temp__1", 169, CPyStatic_globals);
         goto CPyL82;
     }
 CPyL23: ;
@@ -4733,14 +4735,14 @@ CPyL23: ;
     if (!cpy_r_r25) goto CPyL36;
     cpy_r_r26 = ((faster_async_lru___cache_close__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_temp__0;
     if (unlikely(cpy_r_r26 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "cache_close", "cache_close__LRUCacheWrapper_gen", "__mypyc_temp__0", 166, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "cache_close", "cache_close__LRUCacheWrapper_gen", "__mypyc_temp__0", 169, CPyStatic_globals);
         goto CPyL82;
     }
     CPy_INCREF_NO_IMM(cpy_r_r26);
 CPyL25: ;
     cpy_r_r27 = ((faster_async_lru___cache_close__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_temp__1;
     if (unlikely(cpy_r_r27 == -113)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "cache_close", "cache_close__LRUCacheWrapper_gen", "__mypyc_temp__1", 166, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "cache_close", "cache_close__LRUCacheWrapper_gen", "__mypyc_temp__1", 169, CPyStatic_globals);
         goto CPyL83;
     }
 CPyL26: ;
@@ -4762,7 +4764,7 @@ CPyL26: ;
     }
     cpy_r_r34 = ((faster_async_lru___cache_close__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__task;
     if (unlikely(cpy_r_r34 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "cache_close", "cache_close__LRUCacheWrapper_gen", "task", 167, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "cache_close", "cache_close__LRUCacheWrapper_gen", "task", 170, CPyStatic_globals);
         goto CPyL82;
     }
     CPy_INCREF(cpy_r_r34);
@@ -4788,7 +4790,7 @@ CPyL28: ;
     if (cpy_r_r39) goto CPyL34;
     cpy_r_r40 = ((faster_async_lru___cache_close__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__task;
     if (unlikely(cpy_r_r40 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "cache_close", "cache_close__LRUCacheWrapper_gen", "task", 168, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "cache_close", "cache_close__LRUCacheWrapper_gen", "task", 171, CPyStatic_globals);
         goto CPyL82;
     }
     CPy_INCREF(cpy_r_r40);
@@ -4807,7 +4809,7 @@ CPyL33: ;
 CPyL34: ;
     cpy_r_r45 = ((faster_async_lru___cache_close__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_temp__1;
     if (unlikely(cpy_r_r45 == -113)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "cache_close", "cache_close__LRUCacheWrapper_gen", "__mypyc_temp__1", 166, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "cache_close", "cache_close__LRUCacheWrapper_gen", "__mypyc_temp__1", 169, CPyStatic_globals);
         goto CPyL82;
     }
 CPyL35: ;
@@ -4822,7 +4824,7 @@ CPyL35: ;
 CPyL36: ;
     cpy_r_r48 = ((faster_async_lru___cache_close__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__tasks;
     if (unlikely(cpy_r_r48 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "cache_close", "cache_close__LRUCacheWrapper_gen", "tasks", 170, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "cache_close", "cache_close__LRUCacheWrapper_gen", "tasks", 173, CPyStatic_globals);
         goto CPyL82;
     }
     CPy_INCREF_NO_IMM(cpy_r_r48);
@@ -5491,28 +5493,28 @@ PyObject *CPyDef__LRUCacheWrapper___cache_info(PyObject *cpy_r_self) {
     PyObject *cpy_r_r16;
     cpy_r_r0 = ((faster_async_lru____LRUCacheWrapperObject *)cpy_r_self)->___hits;
     if (unlikely(cpy_r_r0 == CPY_INT_TAG)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "cache_info", "_LRUCacheWrapper", "__hits", 174, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "cache_info", "_LRUCacheWrapper", "__hits", 177, CPyStatic_globals);
         goto CPyL8;
     }
     CPyTagged_INCREF(cpy_r_r0);
 CPyL1: ;
     cpy_r_r1 = ((faster_async_lru____LRUCacheWrapperObject *)cpy_r_self)->___misses;
     if (unlikely(cpy_r_r1 == CPY_INT_TAG)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "cache_info", "_LRUCacheWrapper", "__misses", 175, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "cache_info", "_LRUCacheWrapper", "__misses", 178, CPyStatic_globals);
         goto CPyL9;
     }
     CPyTagged_INCREF(cpy_r_r1);
 CPyL2: ;
     cpy_r_r2 = ((faster_async_lru____LRUCacheWrapperObject *)cpy_r_self)->___maxsize;
     if (unlikely(cpy_r_r2 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "cache_info", "_LRUCacheWrapper", "__maxsize", 176, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "cache_info", "_LRUCacheWrapper", "__maxsize", 179, CPyStatic_globals);
         goto CPyL10;
     }
     CPy_INCREF(cpy_r_r2);
 CPyL3: ;
     cpy_r_r3 = ((faster_async_lru____LRUCacheWrapperObject *)cpy_r_self)->___cache;
     if (unlikely(cpy_r_r3 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "cache_info", "_LRUCacheWrapper", "__cache", 177, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "cache_info", "_LRUCacheWrapper", "__cache", 180, CPyStatic_globals);
         goto CPyL11;
     }
     CPy_INCREF(cpy_r_r3);
@@ -5545,7 +5547,7 @@ CPyL4: ;
     if (likely(PyTuple_Check(cpy_r_r14)))
         cpy_r_r15 = cpy_r_r14;
     else {
-        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "cache_info", 173, CPyStatic_globals, "tuple", cpy_r_r14);
+        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "cache_info", 176, CPyStatic_globals, "tuple", cpy_r_r14);
         goto CPyL8;
     }
     return cpy_r_r15;
@@ -5614,14 +5616,14 @@ PyObject *CPyDef__LRUCacheWrapper___cache_parameters(PyObject *cpy_r_self) {
     PyObject *cpy_r_r18;
     cpy_r_r0 = ((faster_async_lru____LRUCacheWrapperObject *)cpy_r_self)->___maxsize;
     if (unlikely(cpy_r_r0 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "cache_parameters", "_LRUCacheWrapper", "__maxsize", 182, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "cache_parameters", "_LRUCacheWrapper", "__maxsize", 185, CPyStatic_globals);
         goto CPyL8;
     }
     CPy_INCREF(cpy_r_r0);
 CPyL1: ;
     cpy_r_r1 = ((faster_async_lru____LRUCacheWrapperObject *)cpy_r_self)->___typed;
     if (unlikely(cpy_r_r1 == 2)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "cache_parameters", "_LRUCacheWrapper", "__typed", 183, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "cache_parameters", "_LRUCacheWrapper", "__typed", 186, CPyStatic_globals);
         goto CPyL9;
     }
 CPyL2: ;
@@ -5637,7 +5639,7 @@ CPyL3: ;
     cpy_r_r5 = cpy_r_r4 << 1;
     cpy_r_r6 = ((faster_async_lru____LRUCacheWrapperObject *)cpy_r_self)->___closed;
     if (unlikely(cpy_r_r6 == 2)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "cache_parameters", "_LRUCacheWrapper", "__closed", 185, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "cache_parameters", "_LRUCacheWrapper", "__closed", 188, CPyStatic_globals);
         goto CPyL9;
     }
 CPyL4: ;
@@ -5665,7 +5667,7 @@ CPyL4: ;
     if (likely(PyDict_Check(cpy_r_r16)))
         cpy_r_r17 = cpy_r_r16;
     else {
-        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "cache_parameters", 181, CPyStatic_globals, "dict", cpy_r_r16);
+        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "cache_parameters", 184, CPyStatic_globals, "dict", cpy_r_r16);
         goto CPyL8;
     }
     return cpy_r_r17;
@@ -5713,7 +5715,7 @@ char CPyDef__LRUCacheWrapper____cache_hit(PyObject *cpy_r_self, PyObject *cpy_r_
     char cpy_r_r8;
     cpy_r_r0 = ((faster_async_lru____LRUCacheWrapperObject *)cpy_r_self)->___hits;
     if (unlikely(cpy_r_r0 == CPY_INT_TAG)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "_cache_hit", "_LRUCacheWrapper", "__hits", 189, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "_cache_hit", "_LRUCacheWrapper", "__hits", 192, CPyStatic_globals);
         goto CPyL5;
     }
 CPyL1: ;
@@ -5729,7 +5731,7 @@ CPyL1: ;
     }
     cpy_r_r3 = ((faster_async_lru____LRUCacheWrapperObject *)cpy_r_self)->___cache;
     if (unlikely(cpy_r_r3 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "_cache_hit", "_LRUCacheWrapper", "__cache", 190, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "_cache_hit", "_LRUCacheWrapper", "__cache", 193, CPyStatic_globals);
         goto CPyL5;
     }
     CPy_INCREF(cpy_r_r3);
@@ -5792,7 +5794,7 @@ char CPyDef__LRUCacheWrapper____cache_miss(PyObject *cpy_r_self, PyObject *cpy_r
     char cpy_r_r3;
     cpy_r_r0 = ((faster_async_lru____LRUCacheWrapperObject *)cpy_r_self)->___misses;
     if (unlikely(cpy_r_r0 == CPY_INT_TAG)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "_cache_miss", "_LRUCacheWrapper", "__misses", 193, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "_cache_miss", "_LRUCacheWrapper", "__misses", 196, CPyStatic_globals);
         goto CPyL3;
     }
 CPyL1: ;
@@ -5909,7 +5911,7 @@ char CPyDef__LRUCacheWrapper____task_done_callback(PyObject *cpy_r_self, PyObjec
 CPyL5: ;
     cpy_r_r9 = ((faster_async_lru____LRUCacheWrapperObject *)cpy_r_self)->___cache;
     if (unlikely(cpy_r_r9 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "_task_done_callback", "_LRUCacheWrapper", "__cache", 200, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "_task_done_callback", "_LRUCacheWrapper", "__cache", 203, CPyStatic_globals);
         goto CPyL26;
     }
     CPy_INCREF(cpy_r_r9);
@@ -5930,7 +5932,7 @@ CPyL7: ;
 CPyL8: ;
     cpy_r_r15 = ((faster_async_lru____LRUCacheWrapperObject *)cpy_r_self)->___cache;
     if (unlikely(cpy_r_r15 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "_task_done_callback", "_LRUCacheWrapper", "__cache", 203, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "_task_done_callback", "_LRUCacheWrapper", "__cache", 206, CPyStatic_globals);
         goto CPyL26;
     }
     CPy_INCREF(cpy_r_r15);
@@ -5952,12 +5954,12 @@ CPyL9: ;
         cpy_r_r17 = NULL;
     }
     if (cpy_r_r17 != NULL) goto __LL14;
-    CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "_task_done_callback", 204, CPyStatic_globals, "faster_async_lru._CacheItem or None", cpy_r_r16);
+    CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "_task_done_callback", 207, CPyStatic_globals, "faster_async_lru._CacheItem or None", cpy_r_r16);
     goto CPyL29;
 __LL14: ;
     cpy_r_r18 = ((faster_async_lru____LRUCacheWrapperObject *)cpy_r_self)->___ttl;
     if (unlikely(cpy_r_r18 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "_task_done_callback", "_LRUCacheWrapper", "__ttl", 205, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "_task_done_callback", "_LRUCacheWrapper", "__ttl", 208, CPyStatic_globals);
         goto CPyL30;
     }
     CPy_INCREF(cpy_r_r18);
@@ -6027,7 +6029,7 @@ CPyL21: ;
     if (likely(cpy_r_r17 != Py_None))
         cpy_r_r37 = cpy_r_r17;
     else {
-        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "_task_done_callback", 208, CPyStatic_globals, "faster_async_lru._CacheItem", cpy_r_r17);
+        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "_task_done_callback", 211, CPyStatic_globals, "faster_async_lru._CacheItem", cpy_r_r17);
         goto CPyL37;
     }
     if (((faster_async_lru____CacheItemObject *)cpy_r_r37)->_later_call != NULL) {
@@ -6229,7 +6231,7 @@ CPyL1: ;
 CPyL4: ;
     cpy_r_r5 = ((faster_async_lru____shield_and_handle_cancelled_error__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__cache_item;
     if (unlikely(cpy_r_r5 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "_shield_and_handle_cancelled_error", "_shield_and_handle_cancelled_error__LRUCacheWrapper_gen", "cache_item", 215, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "_shield_and_handle_cancelled_error", "_shield_and_handle_cancelled_error__LRUCacheWrapper_gen", "cache_item", 218, CPyStatic_globals);
         goto CPyL97;
     }
     CPy_INCREF_NO_IMM(cpy_r_r5);
@@ -6257,7 +6259,7 @@ CPyL6: ;
     }
     cpy_r_r8 = ((faster_async_lru____shield_and_handle_cancelled_error__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__task;
     if (unlikely(cpy_r_r8 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "_shield_and_handle_cancelled_error", "_shield_and_handle_cancelled_error__LRUCacheWrapper_gen", "task", 218, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "_shield_and_handle_cancelled_error", "_shield_and_handle_cancelled_error__LRUCacheWrapper_gen", "task", 221, CPyStatic_globals);
         goto CPyL41;
     }
     CPy_INCREF(cpy_r_r8);
@@ -6480,14 +6482,14 @@ CPyL45: ;
     if (!cpy_r_r43) goto CPyL64;
     cpy_r_r44 = ((faster_async_lru____shield_and_handle_cancelled_error__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__cache_item;
     if (unlikely(cpy_r_r44 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "_shield_and_handle_cancelled_error", "_shield_and_handle_cancelled_error__LRUCacheWrapper_gen", "cache_item", 222, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "_shield_and_handle_cancelled_error", "_shield_and_handle_cancelled_error__LRUCacheWrapper_gen", "cache_item", 225, CPyStatic_globals);
         goto CPyL66;
     }
     CPy_INCREF_NO_IMM(cpy_r_r44);
 CPyL47: ;
     cpy_r_r45 = ((faster_async_lru____CacheItemObject *)cpy_r_r44)->_waiters;
     if (unlikely(cpy_r_r45 == CPY_INT_TAG)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "_shield_and_handle_cancelled_error", "_CacheItem", "waiters", 222, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "_shield_and_handle_cancelled_error", "_CacheItem", "waiters", 225, CPyStatic_globals);
         goto CPyL107;
     }
 CPyL48: ;
@@ -6496,7 +6498,7 @@ CPyL48: ;
     if (!cpy_r_r46) goto CPyL62;
     cpy_r_r47 = ((faster_async_lru____shield_and_handle_cancelled_error__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__task;
     if (unlikely(cpy_r_r47 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "_shield_and_handle_cancelled_error", "_shield_and_handle_cancelled_error__LRUCacheWrapper_gen", "task", 222, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "_shield_and_handle_cancelled_error", "_shield_and_handle_cancelled_error__LRUCacheWrapper_gen", "task", 225, CPyStatic_globals);
         goto CPyL66;
     }
     CPy_INCREF(cpy_r_r47);
@@ -6522,7 +6524,7 @@ CPyL50: ;
     if (cpy_r_r52) goto CPyL62;
     cpy_r_r53 = ((faster_async_lru____shield_and_handle_cancelled_error__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__cache_item;
     if (unlikely(cpy_r_r53 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "_shield_and_handle_cancelled_error", "_shield_and_handle_cancelled_error__LRUCacheWrapper_gen", "cache_item", 223, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "_shield_and_handle_cancelled_error", "_shield_and_handle_cancelled_error__LRUCacheWrapper_gen", "cache_item", 226, CPyStatic_globals);
         goto CPyL66;
     }
     CPy_INCREF_NO_IMM(cpy_r_r53);
@@ -6535,7 +6537,7 @@ CPyL54: ;
     }
     cpy_r_r55 = ((faster_async_lru____shield_and_handle_cancelled_error__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__task;
     if (unlikely(cpy_r_r55 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "_shield_and_handle_cancelled_error", "_shield_and_handle_cancelled_error__LRUCacheWrapper_gen", "task", 224, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "_shield_and_handle_cancelled_error", "_shield_and_handle_cancelled_error__LRUCacheWrapper_gen", "task", 227, CPyStatic_globals);
         goto CPyL66;
     }
     CPy_INCREF(cpy_r_r55);
@@ -6553,7 +6555,7 @@ CPyL57: ;
     CPy_DecRef(cpy_r_r55);
     cpy_r_r60 = ((faster_async_lru____shield_and_handle_cancelled_error__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__self;
     if (unlikely(cpy_r_r60 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "_shield_and_handle_cancelled_error", "_shield_and_handle_cancelled_error__LRUCacheWrapper_gen", "self", 225, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "_shield_and_handle_cancelled_error", "_shield_and_handle_cancelled_error__LRUCacheWrapper_gen", "self", 228, CPyStatic_globals);
         goto CPyL66;
     }
     CPy_INCREF_NO_IMM(cpy_r_r60);
@@ -6572,7 +6574,7 @@ CPyL58: ;
 CPyL59: ;
     cpy_r_r62 = ((faster_async_lru____shield_and_handle_cancelled_error__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__key;
     if (unlikely(cpy_r_r62 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "_shield_and_handle_cancelled_error", "_shield_and_handle_cancelled_error__LRUCacheWrapper_gen", "key", 225, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "_shield_and_handle_cancelled_error", "_shield_and_handle_cancelled_error__LRUCacheWrapper_gen", "key", 228, CPyStatic_globals);
         goto CPyL111;
     }
     CPy_INCREF(cpy_r_r62);
@@ -6636,14 +6638,14 @@ CPyL70: ;
 CPyL72: ;
     cpy_r_r75 = ((faster_async_lru____shield_and_handle_cancelled_error__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__cache_item;
     if (unlikely(cpy_r_r75 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "_shield_and_handle_cancelled_error", "_shield_and_handle_cancelled_error__LRUCacheWrapper_gen", "cache_item", 229, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "_shield_and_handle_cancelled_error", "_shield_and_handle_cancelled_error__LRUCacheWrapper_gen", "cache_item", 232, CPyStatic_globals);
         goto CPyL84;
     }
     CPy_INCREF_NO_IMM(cpy_r_r75);
 CPyL73: ;
     cpy_r_r76 = ((faster_async_lru____CacheItemObject *)cpy_r_r75)->_waiters;
     if (unlikely(cpy_r_r76 == CPY_INT_TAG)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "_shield_and_handle_cancelled_error", "_CacheItem", "waiters", 229, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "_shield_and_handle_cancelled_error", "_CacheItem", "waiters", 232, CPyStatic_globals);
         goto CPyL114;
     }
 CPyL74: ;
@@ -7389,7 +7391,7 @@ CPyL1: ;
 CPyL4: ;
     cpy_r_r11 = ((faster_async_lru_____call___3__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__self;
     if (unlikely(cpy_r_r11 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "self", 234, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "self", 237, CPyStatic_globals);
         goto CPyL188;
     }
     CPy_INCREF_NO_IMM(cpy_r_r11);
@@ -7409,7 +7411,7 @@ CPyL7: ;
     cpy_r_r13 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'alru_cache is closed for ' */
     cpy_r_r14 = ((faster_async_lru_____call___3__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__self;
     if (unlikely(cpy_r_r14 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "self", 235, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "self", 238, CPyStatic_globals);
         goto CPyL188;
     }
     CPy_INCREF_NO_IMM(cpy_r_r14);
@@ -7476,21 +7478,21 @@ CPyL17: ;
     }
     cpy_r_r27 = ((faster_async_lru_____call___3__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__fn_args;
     if (unlikely(cpy_r_r27 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "fn_args", 239, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "fn_args", 242, CPyStatic_globals);
         goto CPyL188;
     }
     CPy_INCREF(cpy_r_r27);
 CPyL20: ;
     cpy_r_r28 = ((faster_async_lru_____call___3__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__fn_kwargs;
     if (unlikely(cpy_r_r28 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "fn_kwargs", 239, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "fn_kwargs", 242, CPyStatic_globals);
         goto CPyL190;
     }
     CPy_INCREF(cpy_r_r28);
 CPyL21: ;
     cpy_r_r29 = ((faster_async_lru_____call___3__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__self;
     if (unlikely(cpy_r_r29 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "self", 239, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "self", 242, CPyStatic_globals);
         goto CPyL191;
     }
     CPy_INCREF_NO_IMM(cpy_r_r29);
@@ -7523,7 +7525,7 @@ CPyL23: ;
     }
     cpy_r_r33 = ((faster_async_lru_____call___3__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__self;
     if (unlikely(cpy_r_r33 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "self", 241, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "self", 244, CPyStatic_globals);
         goto CPyL188;
     }
     CPy_INCREF_NO_IMM(cpy_r_r33);
@@ -7551,14 +7553,14 @@ CPyL27: ;
     }
     cpy_r_r36 = ((faster_async_lru_____call___3__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__cache;
     if (unlikely(cpy_r_r36 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "cache", 243, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "cache", 246, CPyStatic_globals);
         goto CPyL188;
     }
     CPy_INCREF(cpy_r_r36);
 CPyL29: ;
     cpy_r_r37 = ((faster_async_lru_____call___3__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__key;
     if (unlikely(cpy_r_r37 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "key", 243, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "key", 246, CPyStatic_globals);
         goto CPyL192;
     }
     CPy_INCREF(cpy_r_r37);
@@ -7582,7 +7584,7 @@ CPyL30: ;
         cpy_r_r39 = NULL;
     }
     if (cpy_r_r39 != NULL) goto __LL18;
-    CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "__call__", 243, CPyStatic_globals, "faster_async_lru._CacheItem or None", cpy_r_r38);
+    CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "__call__", 246, CPyStatic_globals, "faster_async_lru._CacheItem or None", cpy_r_r38);
     goto CPyL188;
 __LL18: ;
     if (((faster_async_lru_____call___3__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__cache_item != NULL) {
@@ -7596,7 +7598,7 @@ __LL18: ;
     }
     cpy_r_r41 = ((faster_async_lru_____call___3__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__cache_item;
     if (unlikely(cpy_r_r41 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "cache_item", 245, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "cache_item", 248, CPyStatic_globals);
         goto CPyL188;
     }
     CPy_INCREF(cpy_r_r41);
@@ -7607,14 +7609,14 @@ CPyL34: ;
     if (!cpy_r_r43) goto CPyL94;
     cpy_r_r44 = ((faster_async_lru_____call___3__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__self;
     if (unlikely(cpy_r_r44 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "self", 246, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "self", 249, CPyStatic_globals);
         goto CPyL188;
     }
     CPy_INCREF_NO_IMM(cpy_r_r44);
 CPyL36: ;
     cpy_r_r45 = ((faster_async_lru_____call___3__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__key;
     if (unlikely(cpy_r_r45 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "key", 246, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "key", 249, CPyStatic_globals);
         goto CPyL193;
     }
     CPy_INCREF(cpy_r_r45);
@@ -7628,7 +7630,7 @@ CPyL37: ;
     }
     cpy_r_r47 = ((faster_async_lru_____call___3__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__cache_item;
     if (unlikely(cpy_r_r47 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "cache_item", 247, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "cache_item", 250, CPyStatic_globals);
         goto CPyL188;
     }
     CPy_INCREF(cpy_r_r47);
@@ -7636,12 +7638,12 @@ CPyL39: ;
     if (likely(cpy_r_r47 != Py_None))
         cpy_r_r48 = cpy_r_r47;
     else {
-        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "__call__", 247, CPyStatic_globals, "faster_async_lru._CacheItem", cpy_r_r47);
+        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "__call__", 250, CPyStatic_globals, "faster_async_lru._CacheItem", cpy_r_r47);
         goto CPyL194;
     }
     cpy_r_r49 = ((faster_async_lru____CacheItemObject *)cpy_r_r48)->_task;
     if (unlikely(cpy_r_r49 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "_CacheItem", "task", 247, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "_CacheItem", "task", 250, CPyStatic_globals);
         goto CPyL194;
     }
     CPy_INCREF(cpy_r_r49);
@@ -7658,7 +7660,7 @@ CPyL41: ;
     }
     cpy_r_r51 = ((faster_async_lru_____call___3__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__task;
     if (unlikely(cpy_r_r51 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "task", 248, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "task", 251, CPyStatic_globals);
         goto CPyL188;
     }
     CPy_INCREF(cpy_r_r51);
@@ -7684,7 +7686,7 @@ CPyL43: ;
     if (cpy_r_r56) goto CPyL87;
     cpy_r_r57 = ((faster_async_lru_____call___3__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__cache_item;
     if (unlikely(cpy_r_r57 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "cache_item", 250, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "cache_item", 253, CPyStatic_globals);
         goto CPyL188;
     }
     CPy_INCREF(cpy_r_r57);
@@ -7692,12 +7694,12 @@ CPyL47: ;
     if (likely(cpy_r_r57 != Py_None))
         cpy_r_r58 = cpy_r_r57;
     else {
-        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "__call__", 250, CPyStatic_globals, "faster_async_lru._CacheItem", cpy_r_r57);
+        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "__call__", 253, CPyStatic_globals, "faster_async_lru._CacheItem", cpy_r_r57);
         goto CPyL196;
     }
     cpy_r_r59 = ((faster_async_lru____CacheItemObject *)cpy_r_r58)->_waiters;
     if (unlikely(cpy_r_r59 == CPY_INT_TAG)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "_CacheItem", "waiters", 250, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "_CacheItem", "waiters", 253, CPyStatic_globals);
         goto CPyL196;
     }
 CPyL49: ;
@@ -7714,14 +7716,14 @@ CPyL49: ;
     CPy_DECREF(cpy_r_r57);
     cpy_r_r62 = ((faster_async_lru_____call___3__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__self;
     if (unlikely(cpy_r_r62 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "self", 251, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "self", 254, CPyStatic_globals);
         goto CPyL188;
     }
     CPy_INCREF_NO_IMM(cpy_r_r62);
 CPyL51: ;
     cpy_r_r63 = ((faster_async_lru_____call___3__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__cache_item;
     if (unlikely(cpy_r_r63 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "cache_item", 251, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "cache_item", 254, CPyStatic_globals);
         goto CPyL197;
     }
     CPy_INCREF(cpy_r_r63);
@@ -7729,12 +7731,12 @@ CPyL52: ;
     if (likely(cpy_r_r63 != Py_None))
         cpy_r_r64 = cpy_r_r63;
     else {
-        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "__call__", 251, CPyStatic_globals, "faster_async_lru._CacheItem", cpy_r_r63);
+        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "__call__", 254, CPyStatic_globals, "faster_async_lru._CacheItem", cpy_r_r63);
         goto CPyL197;
     }
     cpy_r_r65 = ((faster_async_lru_____call___3__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__key;
     if (unlikely(cpy_r_r65 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "key", 251, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "key", 254, CPyStatic_globals);
         goto CPyL198;
     }
     CPy_INCREF(cpy_r_r65);
@@ -7917,7 +7919,7 @@ CPyL86: ;
 CPyL87: ;
     cpy_r_r94 = ((faster_async_lru_____call___3__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__task;
     if (unlikely(cpy_r_r94 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "task", 254, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "task", 257, CPyStatic_globals);
         goto CPyL188;
     }
     CPy_INCREF(cpy_r_r94);
@@ -7943,21 +7945,21 @@ CPyL93: ;
 CPyL94: ;
     cpy_r_r100 = ((faster_async_lru_____call___3__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__self;
     if (unlikely(cpy_r_r100 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "self", 256, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "self", 259, CPyStatic_globals);
         goto CPyL188;
     }
     CPy_INCREF_NO_IMM(cpy_r_r100);
 CPyL95: ;
     cpy_r_r101 = ((faster_async_lru_____call___3__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__fn_args;
     if (unlikely(cpy_r_r101 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "fn_args", 256, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "fn_args", 259, CPyStatic_globals);
         goto CPyL209;
     }
     CPy_INCREF(cpy_r_r101);
 CPyL96: ;
     cpy_r_r102 = ((faster_async_lru_____call___3__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__fn_kwargs;
     if (unlikely(cpy_r_r102 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "fn_kwargs", 256, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "fn_kwargs", 259, CPyStatic_globals);
         goto CPyL210;
     }
     CPy_INCREF(cpy_r_r102);
@@ -7994,14 +7996,14 @@ CPyL97: ;
     }
     cpy_r_r108 = ((faster_async_lru_____call___3__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__loop;
     if (unlikely(cpy_r_r108 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "loop", 257, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "loop", 260, CPyStatic_globals);
         goto CPyL188;
     }
     CPy_INCREF(cpy_r_r108);
 CPyL102: ;
     cpy_r_r109 = ((faster_async_lru_____call___3__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__coro;
     if (unlikely(cpy_r_r109 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "coro", 257, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "coro", 260, CPyStatic_globals);
         goto CPyL213;
     }
     CPy_INCREF(cpy_r_r109);
@@ -8027,14 +8029,14 @@ CPyL103: ;
     }
     cpy_r_r115 = ((faster_async_lru_____call___3__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__task;
     if (unlikely(cpy_r_r115 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "task", 258, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "task", 261, CPyStatic_globals);
         goto CPyL188;
     }
     CPy_INCREF(cpy_r_r115);
 CPyL106: ;
     cpy_r_r116 = ((faster_async_lru_____call___3__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__self;
     if (unlikely(cpy_r_r116 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "self", 258, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "self", 261, CPyStatic_globals);
         goto CPyL215;
     }
     CPy_INCREF_NO_IMM(cpy_r_r116);
@@ -8048,7 +8050,7 @@ CPyL107: ;
     }
     cpy_r_r119 = ((faster_async_lru_____call___3__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__key;
     if (unlikely(cpy_r_r119 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "key", 258, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "key", 261, CPyStatic_globals);
         goto CPyL216;
     }
     CPy_INCREF(cpy_r_r119);
@@ -8090,7 +8092,7 @@ CPyL114: ;
     CPy_DECREF(cpy_r_r124);
     cpy_r_r129 = ((faster_async_lru_____call___3__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__task;
     if (unlikely(cpy_r_r129 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "task", 260, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "task", 263, CPyStatic_globals);
         goto CPyL188;
     }
     CPy_INCREF(cpy_r_r129);
@@ -8112,7 +8114,7 @@ CPyL115: ;
     }
     cpy_r_r132 = ((faster_async_lru_____call___3__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__cache_item;
     if (unlikely(cpy_r_r132 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "cache_item", 261, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "cache_item", 264, CPyStatic_globals);
         goto CPyL188;
     }
     CPy_INCREF(cpy_r_r132);
@@ -8120,12 +8122,12 @@ CPyL118: ;
     if (likely(cpy_r_r132 != Py_None))
         cpy_r_r133 = cpy_r_r132;
     else {
-        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "__call__", 261, CPyStatic_globals, "faster_async_lru._CacheItem", cpy_r_r132);
+        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "__call__", 264, CPyStatic_globals, "faster_async_lru._CacheItem", cpy_r_r132);
         goto CPyL188;
     }
     cpy_r_r134 = ((faster_async_lru_____call___3__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__self;
     if (unlikely(cpy_r_r134 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "self", 261, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "self", 264, CPyStatic_globals);
         goto CPyL221;
     }
     CPy_INCREF_NO_IMM(cpy_r_r134);
@@ -8144,7 +8146,7 @@ CPyL120: ;
 CPyL121: ;
     cpy_r_r136 = ((faster_async_lru_____call___3__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__key;
     if (unlikely(cpy_r_r136 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "key", 261, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "key", 264, CPyStatic_globals);
         goto CPyL222;
     }
     CPy_INCREF(cpy_r_r136);
@@ -8160,7 +8162,7 @@ CPyL122: ;
     }
     cpy_r_r139 = ((faster_async_lru_____call___3__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__self;
     if (unlikely(cpy_r_r139 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "self", 263, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "self", 266, CPyStatic_globals);
         goto CPyL188;
     }
     CPy_INCREF_NO_IMM(cpy_r_r139);
@@ -8188,7 +8190,7 @@ CPyL125: ;
     }
     cpy_r_r142 = ((faster_async_lru_____call___3__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__maxsize;
     if (unlikely(cpy_r_r142 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "maxsize", 265, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "maxsize", 268, CPyStatic_globals);
         goto CPyL188;
     }
     CPy_INCREF(cpy_r_r142);
@@ -8199,7 +8201,7 @@ CPyL127: ;
     if (!cpy_r_r144) goto CPyL143;
     cpy_r_r145 = ((faster_async_lru_____call___3__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__cache;
     if (unlikely(cpy_r_r145 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "cache", 265, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "cache", 268, CPyStatic_globals);
         goto CPyL188;
     }
     CPy_INCREF(cpy_r_r145);
@@ -8209,7 +8211,7 @@ CPyL129: ;
     cpy_r_r147 = cpy_r_r146 << 1;
     cpy_r_r148 = ((faster_async_lru_____call___3__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__maxsize;
     if (unlikely(cpy_r_r148 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "maxsize", 265, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "maxsize", 268, CPyStatic_globals);
         goto CPyL188;
     }
     CPy_INCREF(cpy_r_r148);
@@ -8242,7 +8244,7 @@ CPyL135: ;
     if (!cpy_r_r155) goto CPyL143;
     cpy_r_r157 = ((faster_async_lru_____call___3__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__cache;
     if (unlikely(cpy_r_r157 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "cache", 266, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "cache", 269, CPyStatic_globals);
         goto CPyL188;
     }
     CPy_INCREF(cpy_r_r157);
@@ -8321,7 +8323,7 @@ __LL20: ;
     }
     cpy_r_r171 = ((faster_async_lru_____call___3__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__dropped_cache_item;
     if (unlikely(cpy_r_r171 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "dropped_cache_item", 267, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "dropped_cache_item", 270, CPyStatic_globals);
         goto CPyL188;
     }
     CPy_INCREF_NO_IMM(cpy_r_r171);
@@ -8335,14 +8337,14 @@ CPyL142: ;
 CPyL143: ;
     cpy_r_r173 = ((faster_async_lru_____call___3__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__self;
     if (unlikely(cpy_r_r173 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "self", 269, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "self", 272, CPyStatic_globals);
         goto CPyL188;
     }
     CPy_INCREF_NO_IMM(cpy_r_r173);
 CPyL144: ;
     cpy_r_r174 = ((faster_async_lru_____call___3__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__key;
     if (unlikely(cpy_r_r174 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "key", 269, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "key", 272, CPyStatic_globals);
         goto CPyL224;
     }
     CPy_INCREF(cpy_r_r174);
@@ -8356,14 +8358,14 @@ CPyL145: ;
     }
     cpy_r_r176 = ((faster_async_lru_____call___3__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__self;
     if (unlikely(cpy_r_r176 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "self", 271, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "self", 274, CPyStatic_globals);
         goto CPyL188;
     }
     CPy_INCREF_NO_IMM(cpy_r_r176);
 CPyL147: ;
     cpy_r_r177 = ((faster_async_lru_____call___3__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__cache_item;
     if (unlikely(cpy_r_r177 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "cache_item", 271, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "cache_item", 274, CPyStatic_globals);
         goto CPyL225;
     }
     CPy_INCREF(cpy_r_r177);
@@ -8371,12 +8373,12 @@ CPyL148: ;
     if (likely(cpy_r_r177 != Py_None))
         cpy_r_r178 = cpy_r_r177;
     else {
-        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "__call__", 271, CPyStatic_globals, "faster_async_lru._CacheItem", cpy_r_r177);
+        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "__call__", 274, CPyStatic_globals, "faster_async_lru._CacheItem", cpy_r_r177);
         goto CPyL225;
     }
     cpy_r_r179 = ((faster_async_lru_____call___3__LRUCacheWrapper_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__key;
     if (unlikely(cpy_r_r179 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "key", 271, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapper_gen", "key", 274, CPyStatic_globals);
         goto CPyL226;
     }
     CPy_INCREF(cpy_r_r179);
@@ -9250,7 +9252,7 @@ char CPyDef__LRUCacheWrapperInstanceMethod_____init__(PyObject *cpy_r_self, PyOb
     char cpy_r_r68;
     cpy_r_r0 = ((faster_async_lru____LRUCacheWrapperObject *)cpy_r_wrapper)->___module__;
     if (unlikely(cpy_r_r0 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__init__", "_LRUCacheWrapper", "__module__", 290, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__init__", "_LRUCacheWrapper", "__module__", 293, CPyStatic_globals);
         goto CPyL3;
     }
     CPy_INCREF(cpy_r_r0);
@@ -9300,7 +9302,7 @@ CPyL8: ;
 CPyL10: ;
     cpy_r_r8 = ((faster_async_lru____LRUCacheWrapperObject *)cpy_r_wrapper)->___name__;
     if (unlikely(cpy_r_r8 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__init__", "_LRUCacheWrapper", "__name__", 294, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__init__", "_LRUCacheWrapper", "__name__", 297, CPyStatic_globals);
         goto CPyL12;
     }
     CPy_INCREF(cpy_r_r8);
@@ -9350,7 +9352,7 @@ CPyL17: ;
 CPyL19: ;
     cpy_r_r16 = ((faster_async_lru____LRUCacheWrapperObject *)cpy_r_wrapper)->___qualname__;
     if (unlikely(cpy_r_r16 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__init__", "_LRUCacheWrapper", "__qualname__", 298, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__init__", "_LRUCacheWrapper", "__qualname__", 301, CPyStatic_globals);
         goto CPyL21;
     }
     CPy_INCREF(cpy_r_r16);
@@ -9400,7 +9402,7 @@ CPyL26: ;
 CPyL28: ;
     cpy_r_r24 = ((faster_async_lru____LRUCacheWrapperObject *)cpy_r_wrapper)->___doc__;
     if (unlikely(cpy_r_r24 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__init__", "_LRUCacheWrapper", "__doc__", 302, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__init__", "_LRUCacheWrapper", "__doc__", 305, CPyStatic_globals);
         goto CPyL30;
     }
     CPy_INCREF(cpy_r_r24);
@@ -9450,7 +9452,7 @@ CPyL35: ;
 CPyL37: ;
     cpy_r_r32 = ((faster_async_lru____LRUCacheWrapperObject *)cpy_r_wrapper)->___annotations__;
     if (unlikely(cpy_r_r32 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__init__", "_LRUCacheWrapper", "__annotations__", 306, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__init__", "_LRUCacheWrapper", "__annotations__", 309, CPyStatic_globals);
         goto CPyL39;
     }
     CPy_INCREF(cpy_r_r32);
@@ -9507,7 +9509,7 @@ CPyL46: ;
     if (likely(PyDict_Check(cpy_r_r41)))
         cpy_r_r42 = cpy_r_r41;
     else {
-        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "__init__", 310, CPyStatic_globals, "dict", cpy_r_r41);
+        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "__init__", 313, CPyStatic_globals, "dict", cpy_r_r41);
         goto CPyL51;
     }
     cpy_r_r43 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__dict__' */
@@ -9519,7 +9521,7 @@ CPyL46: ;
     if (likely(PyDict_Check(cpy_r_r44)))
         cpy_r_r45 = cpy_r_r44;
     else {
-        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "__init__", 310, CPyStatic_globals, "dict", cpy_r_r44);
+        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "__init__", 313, CPyStatic_globals, "dict", cpy_r_r44);
         goto CPyL76;
     }
     cpy_r_r46 = CPyDict_Update(cpy_r_r42, cpy_r_r45);
@@ -9610,7 +9612,7 @@ CPyL62: ;
 CPyL65: ;
     cpy_r_r64 = ((faster_async_lru____LRUCacheWrapperObject *)cpy_r_wrapper)->___wrapped__;
     if (unlikely(cpy_r_r64 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__init__", "_LRUCacheWrapper", "__wrapped__", 317, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__init__", "_LRUCacheWrapper", "__wrapped__", 320, CPyStatic_globals);
         goto CPyL70;
     }
     CPy_INCREF(cpy_r_r64);
@@ -9739,14 +9741,14 @@ char CPyDef__LRUCacheWrapperInstanceMethod___cache_invalidate(PyObject *cpy_r_se
     char cpy_r_r14;
     cpy_r_r0 = ((faster_async_lru____LRUCacheWrapperInstanceMethodObject *)cpy_r_self)->___wrapper;
     if (unlikely(cpy_r_r0 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "cache_invalidate", "_LRUCacheWrapperInstanceMethod", "__wrapper", 322, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "cache_invalidate", "_LRUCacheWrapperInstanceMethod", "__wrapper", 325, CPyStatic_globals);
         goto CPyL11;
     }
     CPy_INCREF_NO_IMM(cpy_r_r0);
 CPyL1: ;
     cpy_r_r1 = ((faster_async_lru____LRUCacheWrapperInstanceMethodObject *)cpy_r_self)->___instance;
     if (unlikely(cpy_r_r1 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "cache_invalidate", "_LRUCacheWrapperInstanceMethod", "__instance", 322, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "cache_invalidate", "_LRUCacheWrapperInstanceMethod", "__instance", 325, CPyStatic_globals);
         goto CPyL12;
     }
     CPy_INCREF(cpy_r_r1);
@@ -9879,7 +9881,7 @@ char CPyDef__LRUCacheWrapperInstanceMethod___cache_clear(PyObject *cpy_r_self) {
     char cpy_r_r2;
     cpy_r_r0 = ((faster_async_lru____LRUCacheWrapperInstanceMethodObject *)cpy_r_self)->___wrapper;
     if (unlikely(cpy_r_r0 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "cache_clear", "_LRUCacheWrapperInstanceMethod", "__wrapper", 325, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "cache_clear", "_LRUCacheWrapperInstanceMethod", "__wrapper", 328, CPyStatic_globals);
         goto CPyL3;
     }
     CPy_INCREF_NO_IMM(cpy_r_r0);
@@ -9986,7 +9988,7 @@ CPyL1: ;
 CPyL4: ;
     cpy_r_r7 = ((faster_async_lru___cache_close__LRUCacheWrapperInstanceMethod_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__self;
     if (unlikely(cpy_r_r7 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "cache_close", "cache_close__LRUCacheWrapperInstanceMethod_gen", "self", 330, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "cache_close", "cache_close__LRUCacheWrapperInstanceMethod_gen", "self", 333, CPyStatic_globals);
         goto CPyL43;
     }
     CPy_INCREF_NO_IMM(cpy_r_r7);
@@ -10609,7 +10611,7 @@ PyObject *CPyDef__LRUCacheWrapperInstanceMethod___cache_info(PyObject *cpy_r_sel
     PyObject *cpy_r_r2;
     cpy_r_r0 = ((faster_async_lru____LRUCacheWrapperInstanceMethodObject *)cpy_r_self)->___wrapper;
     if (unlikely(cpy_r_r0 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "cache_info", "_LRUCacheWrapperInstanceMethod", "__wrapper", 333, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "cache_info", "_LRUCacheWrapperInstanceMethod", "__wrapper", 336, CPyStatic_globals);
         goto CPyL3;
     }
     CPy_INCREF_NO_IMM(cpy_r_r0);
@@ -10653,7 +10655,7 @@ PyObject *CPyDef__LRUCacheWrapperInstanceMethod___cache_parameters(PyObject *cpy
     PyObject *cpy_r_r2;
     cpy_r_r0 = ((faster_async_lru____LRUCacheWrapperInstanceMethodObject *)cpy_r_self)->___wrapper;
     if (unlikely(cpy_r_r0 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "cache_parameters", "_LRUCacheWrapperInstanceMethod", "__wrapper", 336, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "cache_parameters", "_LRUCacheWrapperInstanceMethod", "__wrapper", 339, CPyStatic_globals);
         goto CPyL3;
     }
     CPy_INCREF_NO_IMM(cpy_r_r0);
@@ -10759,14 +10761,14 @@ CPyL1: ;
 CPyL4: ;
     cpy_r_r5 = ((faster_async_lru_____call___3__LRUCacheWrapperInstanceMethod_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__self;
     if (unlikely(cpy_r_r5 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapperInstanceMethod_gen", "self", 339, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapperInstanceMethod_gen", "self", 342, CPyStatic_globals);
         goto CPyL53;
     }
     CPy_INCREF_NO_IMM(cpy_r_r5);
 CPyL5: ;
     cpy_r_r6 = ((faster_async_lru_____call___3__LRUCacheWrapperInstanceMethod_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__self;
     if (unlikely(cpy_r_r6 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapperInstanceMethod_gen", "self", 339, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapperInstanceMethod_gen", "self", 342, CPyStatic_globals);
         goto CPyL54;
     }
     CPy_INCREF_NO_IMM(cpy_r_r6);
@@ -10785,14 +10787,14 @@ CPyL6: ;
 CPyL7: ;
     cpy_r_r8 = ((faster_async_lru_____call___3__LRUCacheWrapperInstanceMethod_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__fn_args;
     if (unlikely(cpy_r_r8 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapperInstanceMethod_gen", "fn_args", 339, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapperInstanceMethod_gen", "fn_args", 342, CPyStatic_globals);
         goto CPyL55;
     }
     CPy_INCREF(cpy_r_r8);
 CPyL8: ;
     cpy_r_r9 = ((faster_async_lru_____call___3__LRUCacheWrapperInstanceMethod_genObject *)cpy_r___mypyc_self__)->___mypyc_generator_attribute__fn_kwargs;
     if (unlikely(cpy_r_r9 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapperInstanceMethod_gen", "fn_kwargs", 339, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "__call__", "__call____LRUCacheWrapperInstanceMethod_gen", "fn_kwargs", 342, CPyStatic_globals);
         goto CPyL56;
     }
     CPy_INCREF(cpy_r_r9);
@@ -11531,56 +11533,50 @@ PyObject *CPyDef_wrapper__make_wrapper_obj_____call__(PyObject *cpy_r___mypyc_se
     PyObject *cpy_r_r17;
     char cpy_r_r18;
     PyObject *cpy_r_r19;
-    PyObject *cpy_r_r20;
+    char cpy_r_r20;
     PyObject *cpy_r_r21;
-    PyObject *cpy_r_r22;
+    char cpy_r_r22;
     PyObject *cpy_r_r23;
-    PyObject **cpy_r_r25;
+    char cpy_r_r24;
+    PyObject *cpy_r_r25;
     PyObject *cpy_r_r26;
     PyObject *cpy_r_r27;
     PyObject *cpy_r_r28;
-    char cpy_r_r29;
-    PyObject *cpy_r_r30;
-    char cpy_r_r31;
+    PyObject *cpy_r_r29;
+    PyObject **cpy_r_r31;
     PyObject *cpy_r_r32;
     PyObject *cpy_r_r33;
     PyObject *cpy_r_r34;
-    PyObject *cpy_r_r35;
-    PyObject *cpy_r_r36;
-    PyObject **cpy_r_r38;
+    CPyPtr cpy_r_r35;
+    CPyPtr cpy_r_r36;
+    CPyPtr cpy_r_r37;
+    PyObject *cpy_r_r38;
     PyObject *cpy_r_r39;
     PyObject *cpy_r_r40;
     PyObject *cpy_r_r41;
-    CPyPtr cpy_r_r42;
-    CPyPtr cpy_r_r43;
-    CPyPtr cpy_r_r44;
+    PyObject **cpy_r_r43;
+    PyObject *cpy_r_r44;
     PyObject *cpy_r_r45;
-    PyObject *cpy_r_r46;
+    char cpy_r_r46;
     PyObject *cpy_r_r47;
-    PyObject *cpy_r_r48;
-    PyObject **cpy_r_r50;
+    PyObject **cpy_r_r49;
+    PyObject *cpy_r_r50;
     PyObject *cpy_r_r51;
-    PyObject *cpy_r_r52;
-    char cpy_r_r53;
+    char cpy_r_r52;
+    PyObject *cpy_r_r53;
     PyObject *cpy_r_r54;
-    PyObject **cpy_r_r56;
-    PyObject *cpy_r_r57;
-    PyObject *cpy_r_r58;
-    char cpy_r_r59;
-    PyObject *cpy_r_r60;
-    PyObject *cpy_r_r61;
     PyObject *cpy_r_wrapper;
-    char cpy_r_r62;
-    char cpy_r_r63;
-    PyObject *cpy_r_r64;
-    char cpy_r_r65;
-    PyObject **cpy_r_r67;
-    PyObject *cpy_r_r68;
-    PyObject *cpy_r_r69;
-    PyObject *cpy_r_r70;
+    char cpy_r_r55;
+    char cpy_r_r56;
+    PyObject *cpy_r_r57;
+    char cpy_r_r58;
+    PyObject **cpy_r_r60;
+    PyObject *cpy_r_r61;
+    PyObject *cpy_r_r62;
+    PyObject *cpy_r_r63;
     cpy_r_r0 = ((faster_async_lru___wrapper__make_wrapper_objObject *)cpy_r___mypyc_self__)->___mypyc_env__;
     if (unlikely(cpy_r_r0 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "wrapper", "wrapper__make_wrapper_obj", "__mypyc_env__", 347, CPyStatic_globals);
+        CPy_AttributeError("faster_async_lru/__init__.py", "wrapper", "wrapper__make_wrapper_obj", "__mypyc_env__", 350, CPyStatic_globals);
         goto CPyL48;
     }
     CPy_INCREF_NO_IMM(cpy_r_r0);
@@ -11672,209 +11668,192 @@ CPyL12: ;
         goto CPyL52;
     }
     if (cpy_r_r18) goto CPyL30;
-    cpy_r_r19 = CPyModule_os;
-    cpy_r_r20 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'environ' */
-    cpy_r_r21 = CPyObject_GetAttr(cpy_r_r19, cpy_r_r20);
-    if (unlikely(cpy_r_r21 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "wrapper", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL52;
-    }
-    cpy_r_r22 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'ASYNC_LRU_ALLOW_SYNC' */
-    cpy_r_r23 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'get' */
-    PyObject *cpy_r_r24[2] = {cpy_r_r21, cpy_r_r22};
-    cpy_r_r25 = (PyObject **)&cpy_r_r24;
-    cpy_r_r26 = PyObject_VectorcallMethod(cpy_r_r23, cpy_r_r25, 9223372036854775810ULL, 0);
-    if (unlikely(cpy_r_r26 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "wrapper", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+    cpy_r_r19 = CPyStatic_ALLOW_SYNC;
+    if (unlikely(cpy_r_r19 == NULL)) {
         goto CPyL53;
+    } else
+        goto CPyL19;
+CPyL17: ;
+    PyErr_SetString(PyExc_NameError, "value for final name \"ALLOW_SYNC\" was not set");
+    cpy_r_r20 = 0;
+    if (unlikely(!cpy_r_r20)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "wrapper", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL48;
     }
-    CPy_DECREF(cpy_r_r21);
-    if (PyUnicode_Check(cpy_r_r26))
-        cpy_r_r27 = cpy_r_r26;
+    CPy_Unreachable();
+CPyL19: ;
+    cpy_r_r21 = (PyObject *)&_Py_NoneStruct;
+    cpy_r_r22 = cpy_r_r19 != cpy_r_r21;
+    if (!cpy_r_r22) goto CPyL54;
+    CPy_INCREF(cpy_r_r19);
+    if (likely(cpy_r_r19 != Py_None))
+        cpy_r_r23 = cpy_r_r19;
     else {
-        cpy_r_r27 = NULL;
-    }
-    if (cpy_r_r27 != NULL) goto __LL36;
-    if (cpy_r_r26 == Py_None)
-        cpy_r_r27 = cpy_r_r26;
-    else {
-        cpy_r_r27 = NULL;
-    }
-    if (cpy_r_r27 != NULL) goto __LL36;
-    CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "wrapper", 353, CPyStatic_globals, "str or None", cpy_r_r26);
-    goto CPyL52;
-__LL36: ;
-    cpy_r_r28 = (PyObject *)&_Py_NoneStruct;
-    cpy_r_r29 = cpy_r_r27 != cpy_r_r28;
-    if (!cpy_r_r29) goto CPyL54;
-    if (likely(cpy_r_r27 != Py_None))
-        cpy_r_r30 = cpy_r_r27;
-    else {
-        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "wrapper", 353, CPyStatic_globals, "str", cpy_r_r27);
+        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "wrapper", 356, CPyStatic_globals, "str", cpy_r_r19);
         goto CPyL52;
     }
-    cpy_r_r31 = CPyStr_IsTrue(cpy_r_r30);
-    CPy_DECREF(cpy_r_r30);
-    if (cpy_r_r31) {
+    cpy_r_r24 = CPyStr_IsTrue(cpy_r_r23);
+    CPy_DECREF(cpy_r_r23);
+    if (cpy_r_r24) {
         goto CPyL30;
     } else
-        goto CPyL55;
+        goto CPyL54;
 CPyL22: ;
-    cpy_r_r32 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '' */
-    cpy_r_r33 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'Coroutine function is required, got ' */
-    cpy_r_r34 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '{!r:{}}' */
-    cpy_r_r35 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '' */
-    cpy_r_r36 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'format' */
-    PyObject *cpy_r_r37[3] = {cpy_r_r34, cpy_r_fn, cpy_r_r35};
-    cpy_r_r38 = (PyObject **)&cpy_r_r37;
-    cpy_r_r39 = PyObject_VectorcallMethod(cpy_r_r36, cpy_r_r38, 9223372036854775811ULL, 0);
-    if (unlikely(cpy_r_r39 == NULL)) {
+    cpy_r_r25 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '' */
+    cpy_r_r26 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'Coroutine function is required, got ' */
+    cpy_r_r27 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '{!r:{}}' */
+    cpy_r_r28 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '' */
+    cpy_r_r29 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'format' */
+    PyObject *cpy_r_r30[3] = {cpy_r_r27, cpy_r_fn, cpy_r_r28};
+    cpy_r_r31 = (PyObject **)&cpy_r_r30;
+    cpy_r_r32 = PyObject_VectorcallMethod(cpy_r_r29, cpy_r_r31, 9223372036854775811ULL, 0);
+    if (unlikely(cpy_r_r32 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "wrapper", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
         goto CPyL48;
     }
-    if (likely(PyUnicode_Check(cpy_r_r39)))
-        cpy_r_r40 = cpy_r_r39;
+    if (likely(PyUnicode_Check(cpy_r_r32)))
+        cpy_r_r33 = cpy_r_r32;
     else {
-        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "wrapper", 354, CPyStatic_globals, "str", cpy_r_r39);
+        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "wrapper", 357, CPyStatic_globals, "str", cpy_r_r32);
         goto CPyL48;
     }
-    cpy_r_r41 = PyList_New(2);
+    cpy_r_r34 = PyList_New(2);
+    if (unlikely(cpy_r_r34 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "wrapper", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL55;
+    }
+    cpy_r_r35 = (CPyPtr)&((PyListObject *)cpy_r_r34)->ob_item;
+    cpy_r_r36 = *(CPyPtr *)cpy_r_r35;
+    CPy_INCREF(cpy_r_r26);
+    *(PyObject * *)cpy_r_r36 = cpy_r_r26;
+    cpy_r_r37 = cpy_r_r36 + 8;
+    *(PyObject * *)cpy_r_r37 = cpy_r_r33;
+    cpy_r_r38 = PyUnicode_Join(cpy_r_r25, cpy_r_r34);
+    CPy_DECREF_NO_IMM(cpy_r_r34);
+    if (unlikely(cpy_r_r38 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "wrapper", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL48;
+    }
+    cpy_r_r39 = CPyModule_builtins;
+    cpy_r_r40 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'RuntimeError' */
+    cpy_r_r41 = CPyObject_GetAttr(cpy_r_r39, cpy_r_r40);
     if (unlikely(cpy_r_r41 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "wrapper", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
         goto CPyL56;
     }
-    cpy_r_r42 = (CPyPtr)&((PyListObject *)cpy_r_r41)->ob_item;
-    cpy_r_r43 = *(CPyPtr *)cpy_r_r42;
-    CPy_INCREF(cpy_r_r33);
-    *(PyObject * *)cpy_r_r43 = cpy_r_r33;
-    cpy_r_r44 = cpy_r_r43 + 8;
-    *(PyObject * *)cpy_r_r44 = cpy_r_r40;
-    cpy_r_r45 = PyUnicode_Join(cpy_r_r32, cpy_r_r41);
-    CPy_DECREF_NO_IMM(cpy_r_r41);
-    if (unlikely(cpy_r_r45 == NULL)) {
+    PyObject *cpy_r_r42[1] = {cpy_r_r38};
+    cpy_r_r43 = (PyObject **)&cpy_r_r42;
+    cpy_r_r44 = PyObject_Vectorcall(cpy_r_r41, cpy_r_r43, 1, 0);
+    CPy_DECREF(cpy_r_r41);
+    if (unlikely(cpy_r_r44 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "wrapper", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL48;
+        goto CPyL56;
     }
-    cpy_r_r46 = CPyModule_builtins;
-    cpy_r_r47 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'RuntimeError' */
-    cpy_r_r48 = CPyObject_GetAttr(cpy_r_r46, cpy_r_r47);
-    if (unlikely(cpy_r_r48 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "wrapper", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL57;
-    }
-    PyObject *cpy_r_r49[1] = {cpy_r_r45};
-    cpy_r_r50 = (PyObject **)&cpy_r_r49;
-    cpy_r_r51 = PyObject_Vectorcall(cpy_r_r48, cpy_r_r50, 1, 0);
-    CPy_DECREF(cpy_r_r48);
-    if (unlikely(cpy_r_r51 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "wrapper", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL57;
-    }
-    CPy_DECREF(cpy_r_r45);
-    CPy_Raise(cpy_r_r51);
-    CPy_DECREF(cpy_r_r51);
+    CPy_DECREF(cpy_r_r38);
+    CPy_Raise(cpy_r_r44);
+    CPy_DECREF(cpy_r_r44);
     if (unlikely(!0)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "wrapper", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
         goto CPyL48;
     }
     CPy_Unreachable();
 CPyL30: ;
-    cpy_r_r52 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_make_unbound_method' */
-    cpy_r_r53 = PyObject_HasAttr(cpy_r_fn, cpy_r_r52);
-    if (!cpy_r_r53) goto CPyL58;
-    cpy_r_r54 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_make_unbound_method' */
-    PyObject *cpy_r_r55[1] = {cpy_r_fn};
-    cpy_r_r56 = (PyObject **)&cpy_r_r55;
-    cpy_r_r57 = PyObject_VectorcallMethod(cpy_r_r54, cpy_r_r56, 9223372036854775809ULL, 0);
-    if (unlikely(cpy_r_r57 == NULL)) {
+    cpy_r_r45 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_make_unbound_method' */
+    cpy_r_r46 = PyObject_HasAttr(cpy_r_fn, cpy_r_r45);
+    if (!cpy_r_r46) goto CPyL57;
+    cpy_r_r47 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_make_unbound_method' */
+    PyObject *cpy_r_r48[1] = {cpy_r_fn};
+    cpy_r_r49 = (PyObject **)&cpy_r_r48;
+    cpy_r_r50 = PyObject_VectorcallMethod(cpy_r_r47, cpy_r_r49, 9223372036854775809ULL, 0);
+    if (unlikely(cpy_r_r50 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "wrapper", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
         goto CPyL52;
     }
-    cpy_r_fn = cpy_r_r57;
+    cpy_r_fn = cpy_r_r50;
 CPyL33: ;
-    cpy_r_r58 = ((faster_async_lru____make_wrapper_envObject *)cpy_r_r0)->_maxsize;
-    if (unlikely(cpy_r_r58 == NULL)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "wrapper", "_make_wrapper_env", "maxsize", 360, CPyStatic_globals);
+    cpy_r_r51 = ((faster_async_lru____make_wrapper_envObject *)cpy_r_r0)->_maxsize;
+    if (unlikely(cpy_r_r51 == NULL)) {
+        CPy_AttributeError("faster_async_lru/__init__.py", "wrapper", "_make_wrapper_env", "maxsize", 363, CPyStatic_globals);
+        goto CPyL58;
+    }
+    CPy_INCREF(cpy_r_r51);
+CPyL34: ;
+    cpy_r_r52 = ((faster_async_lru____make_wrapper_envObject *)cpy_r_r0)->_typed;
+    if (unlikely(cpy_r_r52 == 2)) {
+        CPy_AttributeError("faster_async_lru/__init__.py", "wrapper", "_make_wrapper_env", "typed", 363, CPyStatic_globals);
         goto CPyL59;
     }
-    CPy_INCREF(cpy_r_r58);
-CPyL34: ;
-    cpy_r_r59 = ((faster_async_lru____make_wrapper_envObject *)cpy_r_r0)->_typed;
-    if (unlikely(cpy_r_r59 == 2)) {
-        CPy_AttributeError("faster_async_lru/__init__.py", "wrapper", "_make_wrapper_env", "typed", 360, CPyStatic_globals);
-        goto CPyL60;
-    }
 CPyL35: ;
-    cpy_r_r60 = ((faster_async_lru____make_wrapper_envObject *)cpy_r_r0)->_ttl;
-    if (unlikely(cpy_r_r60 == NULL)) {
+    cpy_r_r53 = ((faster_async_lru____make_wrapper_envObject *)cpy_r_r0)->_ttl;
+    if (unlikely(cpy_r_r53 == NULL)) {
         PyErr_SetString(PyExc_AttributeError, "attribute 'ttl' of '_make_wrapper_env' undefined");
     } else {
-        CPy_INCREF(cpy_r_r60);
+        CPy_INCREF(cpy_r_r53);
     }
     CPy_DECREF_NO_IMM(cpy_r_r0);
-    if (unlikely(cpy_r_r60 == NULL)) {
+    if (unlikely(cpy_r_r53 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "wrapper", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL61;
+        goto CPyL60;
     }
 CPyL36: ;
-    cpy_r_r61 = CPyDef__LRUCacheWrapper(cpy_r_fn, cpy_r_r58, cpy_r_r59, cpy_r_r60);
+    cpy_r_r54 = CPyDef__LRUCacheWrapper(cpy_r_fn, cpy_r_r51, cpy_r_r52, cpy_r_r53);
     CPy_DECREF(cpy_r_fn);
-    CPy_DECREF(cpy_r_r58);
-    CPy_DECREF(cpy_r_r60);
-    if (unlikely(cpy_r_r61 == NULL)) {
+    CPy_DECREF(cpy_r_r51);
+    CPy_DECREF(cpy_r_r53);
+    if (unlikely(cpy_r_r54 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "wrapper", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
         goto CPyL48;
     }
-    cpy_r_wrapper = cpy_r_r61;
-    cpy_r_r62 = CPyStatic__PYTHON_GTE_312;
-    if (unlikely(cpy_r_r62 == 2)) {
-        goto CPyL62;
+    cpy_r_wrapper = cpy_r_r54;
+    cpy_r_r55 = CPyStatic__PYTHON_GTE_312;
+    if (unlikely(cpy_r_r55 == 2)) {
+        goto CPyL61;
     } else
         goto CPyL40;
 CPyL38: ;
     PyErr_SetString(PyExc_NameError, "value for final name \"_PYTHON_GTE_312\" was not set");
-    cpy_r_r63 = 0;
-    if (unlikely(!cpy_r_r63)) {
+    cpy_r_r56 = 0;
+    if (unlikely(!cpy_r_r56)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "wrapper", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
         goto CPyL48;
     }
     CPy_Unreachable();
 CPyL40: ;
-    if (!cpy_r_r62) goto CPyL47;
-    cpy_r_r64 = CPyStatic_markcoroutinefunction;
-    if (unlikely(cpy_r_r64 == NULL)) {
-        goto CPyL63;
+    if (!cpy_r_r55) goto CPyL47;
+    cpy_r_r57 = CPyStatic_markcoroutinefunction;
+    if (unlikely(cpy_r_r57 == NULL)) {
+        goto CPyL62;
     } else
         goto CPyL44;
 CPyL42: ;
     PyErr_SetString(PyExc_NameError, "value for final name \"markcoroutinefunction\" was not set");
-    cpy_r_r65 = 0;
-    if (unlikely(!cpy_r_r65)) {
+    cpy_r_r58 = 0;
+    if (unlikely(!cpy_r_r58)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "wrapper", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
         goto CPyL48;
     }
     CPy_Unreachable();
 CPyL44: ;
-    PyObject *cpy_r_r66[1] = {cpy_r_wrapper};
-    cpy_r_r67 = (PyObject **)&cpy_r_r66;
-    cpy_r_r68 = PyObject_Vectorcall(cpy_r_r64, cpy_r_r67, 1, 0);
-    if (unlikely(cpy_r_r68 == NULL)) {
+    PyObject *cpy_r_r59[1] = {cpy_r_wrapper};
+    cpy_r_r60 = (PyObject **)&cpy_r_r59;
+    cpy_r_r61 = PyObject_Vectorcall(cpy_r_r57, cpy_r_r60, 1, 0);
+    if (unlikely(cpy_r_r61 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "wrapper", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL64;
+        goto CPyL63;
     }
     CPy_DECREF_NO_IMM(cpy_r_wrapper);
-    if (likely(Py_TYPE(cpy_r_r68) == CPyType__LRUCacheWrapper))
-        cpy_r_r69 = cpy_r_r68;
+    if (likely(Py_TYPE(cpy_r_r61) == CPyType__LRUCacheWrapper))
+        cpy_r_r62 = cpy_r_r61;
     else {
-        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "wrapper", 362, CPyStatic_globals, "faster_async_lru._LRUCacheWrapper", cpy_r_r68);
+        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "wrapper", 365, CPyStatic_globals, "faster_async_lru._LRUCacheWrapper", cpy_r_r61);
         goto CPyL48;
     }
-    cpy_r_wrapper = cpy_r_r69;
+    cpy_r_wrapper = cpy_r_r62;
 CPyL47: ;
     return cpy_r_wrapper;
 CPyL48: ;
-    cpy_r_r70 = NULL;
-    return cpy_r_r70;
+    cpy_r_r63 = NULL;
+    return cpy_r_r63;
 CPyL49: ;
     CPy_DecRef(cpy_r_r0);
     CPy_DecRef(cpy_r_origin);
@@ -11892,44 +11871,39 @@ CPyL52: ;
     goto CPyL48;
 CPyL53: ;
     CPy_DecRef(cpy_r_r0);
-    CPy_DecRef(cpy_r_r21);
-    goto CPyL48;
+    goto CPyL17;
 CPyL54: ;
     CPy_DECREF_NO_IMM(cpy_r_r0);
-    CPy_DECREF(cpy_r_r27);
     goto CPyL22;
 CPyL55: ;
-    CPy_DECREF_NO_IMM(cpy_r_r0);
-    goto CPyL22;
+    CPy_DecRef(cpy_r_r33);
+    goto CPyL48;
 CPyL56: ;
-    CPy_DecRef(cpy_r_r40);
+    CPy_DecRef(cpy_r_r38);
     goto CPyL48;
 CPyL57: ;
-    CPy_DecRef(cpy_r_r45);
-    goto CPyL48;
-CPyL58: ;
     CPy_INCREF(cpy_r_fn);
     goto CPyL33;
+CPyL58: ;
+    CPy_DecRef(cpy_r_fn);
+    CPy_DecRef(cpy_r_r0);
+    goto CPyL48;
 CPyL59: ;
     CPy_DecRef(cpy_r_fn);
     CPy_DecRef(cpy_r_r0);
+    CPy_DecRef(cpy_r_r51);
     goto CPyL48;
 CPyL60: ;
     CPy_DecRef(cpy_r_fn);
-    CPy_DecRef(cpy_r_r0);
-    CPy_DecRef(cpy_r_r58);
+    CPy_DecRef(cpy_r_r51);
     goto CPyL48;
 CPyL61: ;
-    CPy_DecRef(cpy_r_fn);
-    CPy_DecRef(cpy_r_r58);
-    goto CPyL48;
-CPyL62: ;
     CPy_DecRef(cpy_r_wrapper);
     goto CPyL38;
-CPyL63: ;
+CPyL62: ;
     CPy_DecRef(cpy_r_wrapper);
     goto CPyL42;
-CPyL64: ;
+CPyL63: ;
     CPy_DecRef(cpy_r_wrapper);
     goto CPyL48;
 }
@@ -12047,16 +12021,16 @@ PyObject *CPyPy__make_wrapper(PyObject *self, PyObject *const *args, size_t narg
     else {
         arg_maxsize = NULL;
     }
-    if (arg_maxsize != NULL) goto __LL37;
+    if (arg_maxsize != NULL) goto __LL36;
     if (obj_maxsize == Py_None)
         arg_maxsize = obj_maxsize;
     else {
         arg_maxsize = NULL;
     }
-    if (arg_maxsize != NULL) goto __LL37;
+    if (arg_maxsize != NULL) goto __LL36;
     CPy_TypeError("int or None", obj_maxsize); 
     goto fail;
-__LL37: ;
+__LL36: ;
     char arg_typed;
     if (unlikely(!PyBool_Check(obj_typed))) {
         CPy_TypeError("bool", obj_typed); goto fail;
@@ -12065,23 +12039,23 @@ __LL37: ;
     PyObject *arg_ttl;
     if (obj_ttl == NULL) {
         arg_ttl = NULL;
-        goto __LL38;
+        goto __LL37;
     }
     if (CPyFloat_Check(obj_ttl))
         arg_ttl = obj_ttl;
     else {
         arg_ttl = NULL;
     }
-    if (arg_ttl != NULL) goto __LL38;
+    if (arg_ttl != NULL) goto __LL37;
     if (obj_ttl == Py_None)
         arg_ttl = obj_ttl;
     else {
         arg_ttl = NULL;
     }
-    if (arg_ttl != NULL) goto __LL38;
+    if (arg_ttl != NULL) goto __LL37;
     CPy_TypeError("float or None", obj_ttl); 
     goto fail;
-__LL38: ;
+__LL37: ;
     PyObject *retval = CPyDef__make_wrapper(arg_maxsize, arg_typed, arg_ttl);
     return retval;
 fail: ;
@@ -12152,16 +12126,16 @@ CPyL8: ;
     else {
         cpy_r_r5 = NULL;
     }
-    if (cpy_r_r5 != NULL) goto __LL39;
+    if (cpy_r_r5 != NULL) goto __LL38;
     if (cpy_r_maxsize == Py_None)
         cpy_r_r5 = cpy_r_maxsize;
     else {
         cpy_r_r5 = NULL;
     }
-    if (cpy_r_r5 != NULL) goto __LL39;
-    CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "alru_cache", 393, CPyStatic_globals, "int or None", cpy_r_maxsize);
+    if (cpy_r_r5 != NULL) goto __LL38;
+    CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "alru_cache", 396, CPyStatic_globals, "int or None", cpy_r_maxsize);
     goto CPyL31;
-__LL39: ;
+__LL38: ;
     cpy_r_r6 = CPyDef__make_wrapper(cpy_r_r5, cpy_r_typed, cpy_r_ttl);
     CPy_DECREF(cpy_r_r5);
     CPy_DECREF(cpy_r_ttl);
@@ -12220,7 +12194,7 @@ CPyL16: ;
     if (likely(Py_TYPE(cpy_r_r21) == CPyType__LRUCacheWrapper))
         cpy_r_r22 = cpy_r_r21;
     else {
-        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "alru_cache", 398, CPyStatic_globals, "faster_async_lru._LRUCacheWrapper", cpy_r_r21);
+        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "alru_cache", 401, CPyStatic_globals, "faster_async_lru._LRUCacheWrapper", cpy_r_r21);
         goto CPyL27;
     }
     return cpy_r_r22;
@@ -12316,25 +12290,25 @@ PyObject *CPyPy_alru_cache(PyObject *self, PyObject *const *args, size_t nargs, 
     PyObject *arg_maxsize;
     if (obj_maxsize == NULL) {
         arg_maxsize = NULL;
-        goto __LL40;
+        goto __LL39;
     }
     if (PyLong_Check(obj_maxsize))
         arg_maxsize = obj_maxsize;
     else {
         arg_maxsize = NULL;
     }
-    if (arg_maxsize != NULL) goto __LL40;
+    if (arg_maxsize != NULL) goto __LL39;
     if (obj_maxsize == Py_None)
         arg_maxsize = obj_maxsize;
     else {
         arg_maxsize = NULL;
     }
-    if (arg_maxsize != NULL) goto __LL40;
+    if (arg_maxsize != NULL) goto __LL39;
     arg_maxsize = obj_maxsize;
-    if (arg_maxsize != NULL) goto __LL40;
+    if (arg_maxsize != NULL) goto __LL39;
     CPy_TypeError("union[int, None, object]", obj_maxsize); 
     goto fail;
-__LL40: ;
+__LL39: ;
     char arg_typed;
     if (obj_typed == NULL) {
         arg_typed = 2;
@@ -12345,23 +12319,23 @@ __LL40: ;
     PyObject *arg_ttl;
     if (obj_ttl == NULL) {
         arg_ttl = NULL;
-        goto __LL41;
+        goto __LL40;
     }
     if (CPyFloat_Check(obj_ttl))
         arg_ttl = obj_ttl;
     else {
         arg_ttl = NULL;
     }
-    if (arg_ttl != NULL) goto __LL41;
+    if (arg_ttl != NULL) goto __LL40;
     if (obj_ttl == Py_None)
         arg_ttl = obj_ttl;
     else {
         arg_ttl = NULL;
     }
-    if (arg_ttl != NULL) goto __LL41;
+    if (arg_ttl != NULL) goto __LL40;
     CPy_TypeError("float or None", obj_ttl); 
     goto fail;
-__LL41: ;
+__LL40: ;
     PyObject *retval = CPyDef_alru_cache(arg_maxsize, arg_typed, arg_ttl);
     return retval;
 fail: ;
@@ -12670,8 +12644,8 @@ CPyL4: ;
     cpy_r_r5 = PyTuple_New(1);
     if (unlikely(cpy_r_r5 == NULL))
         CPyError_OutOfMemory();
-    PyObject *__tmp42 = cpy_r_r3.f0;
-    PyTuple_SET_ITEM(cpy_r_r5, 0, __tmp42);
+    PyObject *__tmp41 = cpy_r_r3.f0;
+    PyTuple_SET_ITEM(cpy_r_r5, 0, __tmp41);
     cpy_r_r6 = PyNumber_InPlaceAdd(cpy_r_key, cpy_r_r5);
     CPy_DECREF(cpy_r_key);
     CPy_DECREF(cpy_r_r5);
@@ -12682,7 +12656,7 @@ CPyL4: ;
     if (likely(PyTuple_Check(cpy_r_r6)))
         cpy_r_r7 = cpy_r_r6;
     else {
-        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "_make_key", 445, CPyStatic_globals, "tuple", cpy_r_r6);
+        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "_make_key", 448, CPyStatic_globals, "tuple", cpy_r_r6);
         goto CPyL36;
     }
     cpy_r_key = cpy_r_r7;
@@ -12710,10 +12684,10 @@ CPyL7: ;
     cpy_r_r17 = PyTuple_New(2);
     if (unlikely(cpy_r_r17 == NULL))
         CPyError_OutOfMemory();
-    PyObject *__tmp43 = cpy_r_r16.f0;
-    PyTuple_SET_ITEM(cpy_r_r17, 0, __tmp43);
-    PyObject *__tmp44 = cpy_r_r16.f1;
-    PyTuple_SET_ITEM(cpy_r_r17, 1, __tmp44);
+    PyObject *__tmp42 = cpy_r_r16.f0;
+    PyTuple_SET_ITEM(cpy_r_r17, 0, __tmp42);
+    PyObject *__tmp43 = cpy_r_r16.f1;
+    PyTuple_SET_ITEM(cpy_r_r17, 1, __tmp43);
     cpy_r_r18 = PyNumber_InPlaceAdd(cpy_r_key, cpy_r_r17);
     CPy_DECREF(cpy_r_key);
     CPy_DECREF(cpy_r_r17);
@@ -12724,7 +12698,7 @@ CPyL7: ;
     if (likely(PyTuple_Check(cpy_r_r18)))
         cpy_r_r19 = cpy_r_r18;
     else {
-        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "_make_key", 447, CPyStatic_globals, "tuple", cpy_r_r18);
+        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "_make_key", 450, CPyStatic_globals, "tuple", cpy_r_r18);
         goto CPyL40;
     }
     cpy_r_key = cpy_r_r19;
@@ -12774,7 +12748,7 @@ CPyL13: ;
     if (likely(PyTuple_Check(cpy_r_r30)))
         cpy_r_r31 = cpy_r_r30;
     else {
-        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "_make_key", 449, CPyStatic_globals, "tuple", cpy_r_r30);
+        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "_make_key", 452, CPyStatic_globals, "tuple", cpy_r_r30);
         goto CPyL36;
     }
     cpy_r_key = cpy_r_r31;
@@ -12820,7 +12794,7 @@ CPyL13: ;
     if (likely(PyTuple_Check(cpy_r_r44)))
         cpy_r_r45 = cpy_r_r44;
     else {
-        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "_make_key", 451, CPyStatic_globals, "tuple", cpy_r_r44);
+        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "_make_key", 454, CPyStatic_globals, "tuple", cpy_r_r44);
         goto CPyL36;
     }
     cpy_r_key = cpy_r_r45;
@@ -12831,23 +12805,23 @@ CPyL27: ;
     cpy_r_r48 = cpy_r_r47 << 1;
     cpy_r_r49 = cpy_r_r48 == 2;
     if (!cpy_r_r49) goto CPyL33;
-    PyObject *__tmp45;
+    PyObject *__tmp44;
     if (unlikely(!(PyTuple_Check(cpy_r_key) && PyTuple_GET_SIZE(cpy_r_key) == 1))) {
-        __tmp45 = NULL;
-        goto __LL46;
+        __tmp44 = NULL;
+        goto __LL45;
     }
-    __tmp45 = PyTuple_GET_ITEM(cpy_r_key, 0);
-    if (__tmp45 == NULL) goto __LL46;
-    __tmp45 = cpy_r_key;
-__LL46: ;
-    if (unlikely(__tmp45 == NULL)) {
+    __tmp44 = PyTuple_GET_ITEM(cpy_r_key, 0);
+    if (__tmp44 == NULL) goto __LL45;
+    __tmp44 = cpy_r_key;
+__LL45: ;
+    if (unlikely(__tmp44 == NULL)) {
         CPy_TypeError("tuple[object]", cpy_r_key); cpy_r_r50 = (tuple_T1O) { NULL };
     } else {
-        PyObject *__tmp47 = PyTuple_GET_ITEM(cpy_r_key, 0);
-        CPy_INCREF(__tmp47);
-        PyObject *__tmp48;
-        __tmp48 = __tmp47;
-        cpy_r_r50.f0 = __tmp48;
+        PyObject *__tmp46 = PyTuple_GET_ITEM(cpy_r_key, 0);
+        CPy_INCREF(__tmp46);
+        PyObject *__tmp47;
+        __tmp47 = __tmp46;
+        cpy_r_r50.f0 = __tmp47;
     }
     if (unlikely(cpy_r_r50.f0 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "_make_key", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
@@ -12873,22 +12847,22 @@ CPyL31: ;
     else {
         cpy_r_r57 = NULL;
     }
-    if (cpy_r_r57 != NULL) goto __LL49;
+    if (cpy_r_r57 != NULL) goto __LL48;
     if (PyLong_Check(cpy_r_r51))
         cpy_r_r57 = cpy_r_r51;
     else {
         cpy_r_r57 = NULL;
     }
-    if (cpy_r_r57 != NULL) goto __LL49;
+    if (cpy_r_r57 != NULL) goto __LL48;
     if (Py_TYPE(cpy_r_r51) == CPyType__HashedSeq)
         cpy_r_r57 = cpy_r_r51;
     else {
         cpy_r_r57 = NULL;
     }
-    if (cpy_r_r57 != NULL) goto __LL49;
-    CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "_make_key", 456, CPyStatic_globals, "union[str, int, faster_async_lru._HashedSeq]", cpy_r_r51);
+    if (cpy_r_r57 != NULL) goto __LL48;
+    CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "_make_key", 459, CPyStatic_globals, "union[str, int, faster_async_lru._HashedSeq]", cpy_r_r51);
     goto CPyL36;
-__LL49: ;
+__LL48: ;
     return cpy_r_r57;
 CPyL33: ;
     cpy_r_r58 = (PyObject *)CPyType__HashedSeq;
@@ -12903,7 +12877,7 @@ CPyL33: ;
     if (likely(Py_TYPE(cpy_r_r61) == CPyType__HashedSeq))
         cpy_r_r62 = cpy_r_r61;
     else {
-        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "_make_key", 457, CPyStatic_globals, "faster_async_lru._HashedSeq", cpy_r_r61);
+        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "_make_key", 460, CPyStatic_globals, "faster_async_lru._HashedSeq", cpy_r_r61);
         goto CPyL36;
     }
     return cpy_r_r62;
@@ -13051,86 +13025,85 @@ char CPyDef___top_level__(void) {
     PyObject *cpy_r_r70;
     PyObject *cpy_r_r71;
     PyObject *cpy_r_r72;
-    PyObject **cpy_r_r74;
-    PyObject *cpy_r_r75;
+    PyObject *cpy_r_r73;
+    PyObject **cpy_r_r75;
     PyObject *cpy_r_r76;
     PyObject *cpy_r_r77;
-    int32_t cpy_r_r78;
-    char cpy_r_r79;
-    PyObject *cpy_r_r80;
-    PyObject *cpy_r_r81;
+    PyObject *cpy_r_r78;
+    PyObject *cpy_r_r79;
+    int32_t cpy_r_r80;
+    char cpy_r_r81;
     PyObject *cpy_r_r82;
     PyObject *cpy_r_r83;
-    PyObject **cpy_r_r85;
-    PyObject *cpy_r_r86;
-    PyObject *cpy_r_r87;
+    PyObject *cpy_r_r84;
+    PyObject *cpy_r_r85;
+    PyObject **cpy_r_r87;
     PyObject *cpy_r_r88;
-    int32_t cpy_r_r89;
-    char cpy_r_r90;
-    PyObject *cpy_r_r91;
-    PyObject *cpy_r_r92;
+    PyObject *cpy_r_r89;
+    PyObject *cpy_r_r90;
+    int32_t cpy_r_r91;
+    char cpy_r_r92;
     PyObject *cpy_r_r93;
     PyObject *cpy_r_r94;
     PyObject *cpy_r_r95;
     PyObject *cpy_r_r96;
-    PyObject *cpy_r_r97;
-    PyObject *cpy_r_r98;
+    PyObject **cpy_r_r98;
     PyObject *cpy_r_r99;
     PyObject *cpy_r_r100;
     PyObject *cpy_r_r101;
-    PyObject *cpy_r_r102;
-    tuple_T3OOO cpy_r_r103;
+    int32_t cpy_r_r102;
+    char cpy_r_r103;
     PyObject *cpy_r_r104;
     PyObject *cpy_r_r105;
     PyObject *cpy_r_r106;
     PyObject *cpy_r_r107;
-    int32_t cpy_r_r108;
-    char cpy_r_r109;
+    PyObject *cpy_r_r108;
+    PyObject *cpy_r_r109;
     PyObject *cpy_r_r110;
     PyObject *cpy_r_r111;
     PyObject *cpy_r_r112;
     PyObject *cpy_r_r113;
     PyObject *cpy_r_r114;
     PyObject *cpy_r_r115;
-    PyObject *cpy_r_r116;
+    tuple_T3OOO cpy_r_r116;
     PyObject *cpy_r_r117;
     PyObject *cpy_r_r118;
     PyObject *cpy_r_r119;
     PyObject *cpy_r_r120;
-    tuple_T2OO cpy_r_r121;
-    PyObject *cpy_r_r122;
+    int32_t cpy_r_r121;
+    char cpy_r_r122;
     PyObject *cpy_r_r123;
     PyObject *cpy_r_r124;
     PyObject *cpy_r_r125;
-    int32_t cpy_r_r126;
-    char cpy_r_r127;
+    PyObject *cpy_r_r126;
+    PyObject *cpy_r_r127;
     PyObject *cpy_r_r128;
     PyObject *cpy_r_r129;
     PyObject *cpy_r_r130;
     PyObject *cpy_r_r131;
     PyObject *cpy_r_r132;
     PyObject *cpy_r_r133;
-    PyObject *cpy_r_r134;
+    tuple_T2OO cpy_r_r134;
     PyObject *cpy_r_r135;
     PyObject *cpy_r_r136;
     PyObject *cpy_r_r137;
     PyObject *cpy_r_r138;
-    PyObject *cpy_r_r139;
-    tuple_T3OOO cpy_r_r140;
+    int32_t cpy_r_r139;
+    char cpy_r_r140;
     PyObject *cpy_r_r141;
     PyObject *cpy_r_r142;
     PyObject *cpy_r_r143;
     PyObject *cpy_r_r144;
-    int32_t cpy_r_r145;
-    char cpy_r_r146;
+    PyObject *cpy_r_r145;
+    PyObject *cpy_r_r146;
     PyObject *cpy_r_r147;
     PyObject *cpy_r_r148;
     PyObject *cpy_r_r149;
     PyObject *cpy_r_r150;
-    tuple_T2II cpy_r_r151;
+    PyObject *cpy_r_r151;
     PyObject *cpy_r_r152;
-    PyObject *cpy_r_r153;
-    char cpy_r_r154;
+    tuple_T3OOO cpy_r_r153;
+    PyObject *cpy_r_r154;
     PyObject *cpy_r_r155;
     PyObject *cpy_r_r156;
     PyObject *cpy_r_r157;
@@ -13153,79 +13126,79 @@ char CPyDef___top_level__(void) {
     PyObject *cpy_r_r174;
     PyObject *cpy_r_r175;
     PyObject *cpy_r_r176;
-    PyObject *cpy_r_r177;
+    tuple_T2II cpy_r_r177;
     PyObject *cpy_r_r178;
-    CPyPtr cpy_r_r179;
-    CPyPtr cpy_r_r180;
-    CPyPtr cpy_r_r181;
-    CPyPtr cpy_r_r182;
-    CPyPtr cpy_r_r183;
-    PyObject *cpy_r_r184;
-    PyObject *cpy_r_r185;
+    PyObject *cpy_r_r179;
+    char cpy_r_r180;
+    PyObject *cpy_r_r181;
+    PyObject *cpy_r_r182;
+    PyObject *cpy_r_r183;
+    int32_t cpy_r_r184;
+    char cpy_r_r185;
     PyObject *cpy_r_r186;
-    PyObject **cpy_r_r188;
+    PyObject *cpy_r_r187;
+    PyObject *cpy_r_r188;
     PyObject *cpy_r_r189;
     PyObject *cpy_r_r190;
     PyObject *cpy_r_r191;
-    int32_t cpy_r_r192;
-    char cpy_r_r193;
-    PyObject *cpy_r_r194;
-    PyObject *cpy_r_r195;
-    PyObject *cpy_r_r196;
+    CPyPtr cpy_r_r192;
+    CPyPtr cpy_r_r193;
+    CPyPtr cpy_r_r194;
+    CPyPtr cpy_r_r195;
+    CPyPtr cpy_r_r196;
     PyObject *cpy_r_r197;
     PyObject *cpy_r_r198;
-    int32_t cpy_r_r199;
-    char cpy_r_r200;
-    PyObject *cpy_r_r201;
+    PyObject *cpy_r_r199;
+    PyObject **cpy_r_r201;
     PyObject *cpy_r_r202;
     PyObject *cpy_r_r203;
     PyObject *cpy_r_r204;
-    PyObject *cpy_r_r205;
-    int32_t cpy_r_r206;
-    char cpy_r_r207;
+    int32_t cpy_r_r205;
+    char cpy_r_r206;
+    PyObject *cpy_r_r207;
     PyObject *cpy_r_r208;
     PyObject *cpy_r_r209;
     PyObject *cpy_r_r210;
     PyObject *cpy_r_r211;
-    PyObject *cpy_r_r212;
-    int32_t cpy_r_r213;
-    char cpy_r_r214;
+    int32_t cpy_r_r212;
+    char cpy_r_r213;
+    PyObject *cpy_r_r214;
     PyObject *cpy_r_r215;
     PyObject *cpy_r_r216;
     PyObject *cpy_r_r217;
     PyObject *cpy_r_r218;
-    PyObject *cpy_r_r219;
-    int32_t cpy_r_r220;
-    char cpy_r_r221;
+    int32_t cpy_r_r219;
+    char cpy_r_r220;
+    PyObject *cpy_r_r221;
     PyObject *cpy_r_r222;
     PyObject *cpy_r_r223;
     PyObject *cpy_r_r224;
     PyObject *cpy_r_r225;
-    PyObject *cpy_r_r226;
-    int32_t cpy_r_r227;
-    char cpy_r_r228;
+    int32_t cpy_r_r226;
+    char cpy_r_r227;
+    PyObject *cpy_r_r228;
     PyObject *cpy_r_r229;
     PyObject *cpy_r_r230;
     PyObject *cpy_r_r231;
     PyObject *cpy_r_r232;
-    PyObject *cpy_r_r233;
-    int32_t cpy_r_r234;
-    char cpy_r_r235;
-    char cpy_r_r236;
-    char cpy_r_r237;
+    int32_t cpy_r_r233;
+    char cpy_r_r234;
+    PyObject *cpy_r_r235;
+    PyObject *cpy_r_r236;
+    PyObject *cpy_r_r237;
     PyObject *cpy_r_r238;
     PyObject *cpy_r_r239;
-    PyObject *cpy_r_r240;
-    PyObject *cpy_r_r241;
+    int32_t cpy_r_r240;
+    char cpy_r_r241;
     PyObject *cpy_r_r242;
     PyObject *cpy_r_r243;
     PyObject *cpy_r_r244;
-    int32_t cpy_r_r245;
-    char cpy_r_r246;
-    PyObject *cpy_r_r247;
-    PyObject *cpy_r_r248;
+    PyObject *cpy_r_r245;
+    PyObject *cpy_r_r246;
+    int32_t cpy_r_r247;
+    char cpy_r_r248;
     char cpy_r_r249;
-    PyObject *cpy_r_r250;
+    char cpy_r_r250;
     PyObject *cpy_r_r251;
     PyObject *cpy_r_r252;
     PyObject *cpy_r_r253;
@@ -13233,22 +13206,23 @@ char CPyDef___top_level__(void) {
     PyObject *cpy_r_r255;
     PyObject *cpy_r_r256;
     PyObject *cpy_r_r257;
-    PyObject *cpy_r_r258;
-    PyObject *cpy_r_r259;
-    char cpy_r_r260;
+    int32_t cpy_r_r258;
+    char cpy_r_r259;
+    PyObject *cpy_r_r260;
     PyObject *cpy_r_r261;
-    PyObject *cpy_r_r262;
+    char cpy_r_r262;
     PyObject *cpy_r_r263;
     PyObject *cpy_r_r264;
     PyObject *cpy_r_r265;
     PyObject *cpy_r_r266;
     PyObject *cpy_r_r267;
     PyObject *cpy_r_r268;
-    char cpy_r_r269;
+    PyObject *cpy_r_r269;
     PyObject *cpy_r_r270;
     PyObject *cpy_r_r271;
     PyObject *cpy_r_r272;
-    PyObject **cpy_r_r274;
+    char cpy_r_r273;
+    PyObject *cpy_r_r274;
     PyObject *cpy_r_r275;
     PyObject *cpy_r_r276;
     PyObject *cpy_r_r277;
@@ -13256,55 +13230,54 @@ char CPyDef___top_level__(void) {
     PyObject *cpy_r_r279;
     PyObject *cpy_r_r280;
     PyObject *cpy_r_r281;
-    int32_t cpy_r_r282;
-    char cpy_r_r283;
+    char cpy_r_r282;
+    PyObject *cpy_r_r283;
     PyObject *cpy_r_r284;
     PyObject *cpy_r_r285;
-    int32_t cpy_r_r286;
-    char cpy_r_r287;
+    PyObject **cpy_r_r287;
     PyObject *cpy_r_r288;
     PyObject *cpy_r_r289;
-    int32_t cpy_r_r290;
-    char cpy_r_r291;
+    PyObject *cpy_r_r290;
+    PyObject *cpy_r_r291;
     PyObject *cpy_r_r292;
     PyObject *cpy_r_r293;
-    int32_t cpy_r_r294;
-    char cpy_r_r295;
-    PyObject *cpy_r_r296;
+    PyObject *cpy_r_r294;
+    int32_t cpy_r_r295;
+    char cpy_r_r296;
     PyObject *cpy_r_r297;
-    int32_t cpy_r_r298;
-    char cpy_r_r299;
-    PyObject *cpy_r_r300;
+    PyObject *cpy_r_r298;
+    int32_t cpy_r_r299;
+    char cpy_r_r300;
     PyObject *cpy_r_r301;
-    int32_t cpy_r_r302;
-    char cpy_r_r303;
-    PyObject *cpy_r_r304;
+    PyObject *cpy_r_r302;
+    int32_t cpy_r_r303;
+    char cpy_r_r304;
     PyObject *cpy_r_r305;
-    int32_t cpy_r_r306;
-    char cpy_r_r307;
-    PyObject **cpy_r_r309;
+    PyObject *cpy_r_r306;
+    int32_t cpy_r_r307;
+    char cpy_r_r308;
+    PyObject *cpy_r_r309;
     PyObject *cpy_r_r310;
-    PyObject *cpy_r_r311;
-    PyObject *cpy_r_r312;
+    int32_t cpy_r_r311;
+    char cpy_r_r312;
     PyObject *cpy_r_r313;
-    PyObject **cpy_r_r315;
-    PyObject *cpy_r_r316;
+    PyObject *cpy_r_r314;
+    int32_t cpy_r_r315;
+    char cpy_r_r316;
     PyObject *cpy_r_r317;
     PyObject *cpy_r_r318;
     int32_t cpy_r_r319;
     char cpy_r_r320;
-    PyObject *cpy_r_r321;
-    PyObject *cpy_r_r322;
+    PyObject **cpy_r_r322;
     PyObject *cpy_r_r323;
     PyObject *cpy_r_r324;
     PyObject *cpy_r_r325;
     PyObject *cpy_r_r326;
-    PyObject *cpy_r_r327;
-    PyObject *cpy_r_r328;
+    PyObject **cpy_r_r328;
     PyObject *cpy_r_r329;
     PyObject *cpy_r_r330;
     PyObject *cpy_r_r331;
-    PyObject *cpy_r_r332;
+    int32_t cpy_r_r332;
     char cpy_r_r333;
     PyObject *cpy_r_r334;
     PyObject *cpy_r_r335;
@@ -13312,25 +13285,25 @@ char CPyDef___top_level__(void) {
     PyObject *cpy_r_r337;
     PyObject *cpy_r_r338;
     PyObject *cpy_r_r339;
-    int32_t cpy_r_r340;
-    char cpy_r_r341;
+    PyObject *cpy_r_r340;
+    PyObject *cpy_r_r341;
     PyObject *cpy_r_r342;
     PyObject *cpy_r_r343;
-    int32_t cpy_r_r344;
-    char cpy_r_r345;
-    PyObject *cpy_r_r346;
+    PyObject *cpy_r_r344;
+    PyObject *cpy_r_r345;
+    char cpy_r_r346;
     PyObject *cpy_r_r347;
     PyObject *cpy_r_r348;
     PyObject *cpy_r_r349;
     PyObject *cpy_r_r350;
     PyObject *cpy_r_r351;
     PyObject *cpy_r_r352;
-    PyObject *cpy_r_r353;
-    PyObject *cpy_r_r354;
+    int32_t cpy_r_r353;
+    char cpy_r_r354;
     PyObject *cpy_r_r355;
     PyObject *cpy_r_r356;
-    char cpy_r_r357;
-    PyObject *cpy_r_r358;
+    int32_t cpy_r_r357;
+    char cpy_r_r358;
     PyObject *cpy_r_r359;
     PyObject *cpy_r_r360;
     PyObject *cpy_r_r361;
@@ -13342,17 +13315,17 @@ char CPyDef___top_level__(void) {
     PyObject *cpy_r_r367;
     PyObject *cpy_r_r368;
     PyObject *cpy_r_r369;
-    PyObject *cpy_r_r370;
+    char cpy_r_r370;
     PyObject *cpy_r_r371;
     PyObject *cpy_r_r372;
     PyObject *cpy_r_r373;
     PyObject *cpy_r_r374;
-    int32_t cpy_r_r375;
-    char cpy_r_r376;
+    PyObject *cpy_r_r375;
+    PyObject *cpy_r_r376;
     PyObject *cpy_r_r377;
     PyObject *cpy_r_r378;
-    int32_t cpy_r_r379;
-    char cpy_r_r380;
+    PyObject *cpy_r_r379;
+    PyObject *cpy_r_r380;
     PyObject *cpy_r_r381;
     PyObject *cpy_r_r382;
     PyObject *cpy_r_r383;
@@ -13360,34 +13333,34 @@ char CPyDef___top_level__(void) {
     PyObject *cpy_r_r385;
     PyObject *cpy_r_r386;
     PyObject *cpy_r_r387;
-    PyObject *cpy_r_r388;
-    PyObject *cpy_r_r389;
-    tuple_T2OO cpy_r_r390;
+    int32_t cpy_r_r388;
+    char cpy_r_r389;
+    PyObject *cpy_r_r390;
     PyObject *cpy_r_r391;
-    PyObject *cpy_r_r392;
-    PyObject *cpy_r_r393;
+    int32_t cpy_r_r392;
+    char cpy_r_r393;
     PyObject *cpy_r_r394;
     PyObject *cpy_r_r395;
     PyObject *cpy_r_r396;
-    char cpy_r_r397;
+    PyObject *cpy_r_r397;
     PyObject *cpy_r_r398;
     PyObject *cpy_r_r399;
     PyObject *cpy_r_r400;
     PyObject *cpy_r_r401;
     PyObject *cpy_r_r402;
-    PyObject *cpy_r_r403;
+    tuple_T2OO cpy_r_r403;
     PyObject *cpy_r_r404;
     PyObject *cpy_r_r405;
     PyObject *cpy_r_r406;
     PyObject *cpy_r_r407;
     PyObject *cpy_r_r408;
     PyObject *cpy_r_r409;
-    int32_t cpy_r_r410;
-    char cpy_r_r411;
+    char cpy_r_r410;
+    PyObject *cpy_r_r411;
     PyObject *cpy_r_r412;
     PyObject *cpy_r_r413;
-    int32_t cpy_r_r414;
-    char cpy_r_r415;
+    PyObject *cpy_r_r414;
+    PyObject *cpy_r_r415;
     PyObject *cpy_r_r416;
     PyObject *cpy_r_r417;
     PyObject *cpy_r_r418;
@@ -13395,11 +13368,12 @@ char CPyDef___top_level__(void) {
     PyObject *cpy_r_r420;
     PyObject *cpy_r_r421;
     PyObject *cpy_r_r422;
-    char cpy_r_r423;
-    PyObject *cpy_r_r424;
+    int32_t cpy_r_r423;
+    char cpy_r_r424;
     PyObject *cpy_r_r425;
     PyObject *cpy_r_r426;
-    PyObject **cpy_r_r428;
+    int32_t cpy_r_r427;
+    char cpy_r_r428;
     PyObject *cpy_r_r429;
     PyObject *cpy_r_r430;
     PyObject *cpy_r_r431;
@@ -13407,64 +13381,76 @@ char CPyDef___top_level__(void) {
     PyObject *cpy_r_r433;
     PyObject *cpy_r_r434;
     PyObject *cpy_r_r435;
-    int32_t cpy_r_r436;
-    char cpy_r_r437;
+    char cpy_r_r436;
+    PyObject *cpy_r_r437;
     PyObject *cpy_r_r438;
     PyObject *cpy_r_r439;
-    int32_t cpy_r_r440;
-    char cpy_r_r441;
+    PyObject **cpy_r_r441;
     PyObject *cpy_r_r442;
     PyObject *cpy_r_r443;
-    int32_t cpy_r_r444;
-    char cpy_r_r445;
+    PyObject *cpy_r_r444;
+    PyObject *cpy_r_r445;
     PyObject *cpy_r_r446;
     PyObject *cpy_r_r447;
-    int32_t cpy_r_r448;
-    char cpy_r_r449;
-    PyObject *cpy_r_r450;
+    PyObject *cpy_r_r448;
+    int32_t cpy_r_r449;
+    char cpy_r_r450;
     PyObject *cpy_r_r451;
-    int32_t cpy_r_r452;
-    char cpy_r_r453;
-    PyObject *cpy_r_r454;
+    PyObject *cpy_r_r452;
+    int32_t cpy_r_r453;
+    char cpy_r_r454;
     PyObject *cpy_r_r455;
-    int32_t cpy_r_r456;
-    char cpy_r_r457;
-    PyObject *cpy_r_r458;
+    PyObject *cpy_r_r456;
+    int32_t cpy_r_r457;
+    char cpy_r_r458;
     PyObject *cpy_r_r459;
-    int32_t cpy_r_r460;
-    char cpy_r_r461;
-    PyObject **cpy_r_r463;
+    PyObject *cpy_r_r460;
+    int32_t cpy_r_r461;
+    char cpy_r_r462;
+    PyObject *cpy_r_r463;
     PyObject *cpy_r_r464;
-    PyObject *cpy_r_r465;
-    PyObject *cpy_r_r466;
+    int32_t cpy_r_r465;
+    char cpy_r_r466;
     PyObject *cpy_r_r467;
     PyObject *cpy_r_r468;
-    PyObject **cpy_r_r470;
+    int32_t cpy_r_r469;
+    char cpy_r_r470;
     PyObject *cpy_r_r471;
     PyObject *cpy_r_r472;
-    PyObject **cpy_r_r474;
-    PyObject *cpy_r_r475;
-    PyObject *cpy_r_r476;
+    int32_t cpy_r_r473;
+    char cpy_r_r474;
+    PyObject **cpy_r_r476;
     PyObject *cpy_r_r477;
     PyObject *cpy_r_r478;
-    PyObject **cpy_r_r480;
+    PyObject *cpy_r_r479;
+    PyObject *cpy_r_r480;
     PyObject *cpy_r_r481;
-    PyObject *cpy_r_r482;
-    PyObject *cpy_r_r483;
-    int32_t cpy_r_r484;
-    char cpy_r_r485;
-    PyObject *cpy_r_r486;
-    PyObject *cpy_r_r487;
+    PyObject **cpy_r_r483;
+    PyObject *cpy_r_r484;
+    PyObject *cpy_r_r485;
+    PyObject **cpy_r_r487;
     PyObject *cpy_r_r488;
     PyObject *cpy_r_r489;
     PyObject *cpy_r_r490;
-    tuple_T1O cpy_r_r491;
-    PyObject *cpy_r_r492;
-    PyObject *cpy_r_r493;
+    PyObject *cpy_r_r491;
+    PyObject **cpy_r_r493;
     PyObject *cpy_r_r494;
-    int32_t cpy_r_r495;
-    char cpy_r_r496;
-    char cpy_r_r497;
+    PyObject *cpy_r_r495;
+    PyObject *cpy_r_r496;
+    int32_t cpy_r_r497;
+    char cpy_r_r498;
+    PyObject *cpy_r_r499;
+    PyObject *cpy_r_r500;
+    PyObject *cpy_r_r501;
+    PyObject *cpy_r_r502;
+    PyObject *cpy_r_r503;
+    tuple_T1O cpy_r_r504;
+    PyObject *cpy_r_r505;
+    PyObject *cpy_r_r506;
+    PyObject *cpy_r_r507;
+    int32_t cpy_r_r508;
+    char cpy_r_r509;
+    char cpy_r_r510;
     cpy_r_r0 = CPyModule_builtins;
     cpy_r_r1 = (PyObject *)&_Py_NoneStruct;
     cpy_r_r2 = cpy_r_r0 != cpy_r_r1;
@@ -13473,7 +13459,7 @@ char CPyDef___top_level__(void) {
     cpy_r_r4 = PyImport_Import(cpy_r_r3);
     if (unlikely(cpy_r_r4 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", -1, CPyStatic_globals);
-        goto CPyL173;
+        goto CPyL177;
     }
     CPyModule_builtins = cpy_r_r4;
     CPy_INCREF(CPyModule_builtins);
@@ -13496,14 +13482,14 @@ CPyL3: ;
     cpy_r_r16 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'faster_async_lru/__init__.py' */
     cpy_r_r17 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '<module>' */
     cpy_r_r18 = CPyImport_ImportMany(cpy_r_r14, cpy_r_r11, cpy_r_r15, cpy_r_r16, cpy_r_r17, cpy_r_r13);
-    if (!cpy_r_r18) goto CPyL173;
+    if (!cpy_r_r18) goto CPyL177;
     cpy_r_r19 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* ('OrderedDict', 'namedtuple') */
     cpy_r_r20 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'collections' */
     cpy_r_r21 = CPyStatic_globals;
     cpy_r_r22 = CPyImport_ImportFromMany(cpy_r_r20, cpy_r_r19, cpy_r_r19, cpy_r_r21);
     if (unlikely(cpy_r_r22 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
+        goto CPyL177;
     }
     CPyModule_collections = cpy_r_r22;
     CPy_INCREF(CPyModule_collections);
@@ -13514,7 +13500,7 @@ CPyL3: ;
     cpy_r_r26 = CPyImport_ImportFromMany(cpy_r_r24, cpy_r_r23, cpy_r_r23, cpy_r_r25);
     if (unlikely(cpy_r_r26 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
+        goto CPyL177;
     }
     CPyModule_collections___abc = cpy_r_r26;
     CPy_INCREF(CPyModule_collections___abc);
@@ -13526,7 +13512,7 @@ CPyL3: ;
     cpy_r_r30 = CPyImport_ImportFromMany(cpy_r_r28, cpy_r_r27, cpy_r_r27, cpy_r_r29);
     if (unlikely(cpy_r_r30 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
+        goto CPyL177;
     }
     CPyModule_typing = cpy_r_r30;
     CPy_INCREF(CPyModule_typing);
@@ -13537,7 +13523,7 @@ CPyL3: ;
     cpy_r_r34 = CPyImport_ImportFromMany(cpy_r_r32, cpy_r_r31, cpy_r_r31, cpy_r_r33);
     if (unlikely(cpy_r_r34 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
+        goto CPyL177;
     }
     CPyModule_mypy_extensions = cpy_r_r34;
     CPy_INCREF(CPyModule_mypy_extensions);
@@ -13547,29 +13533,29 @@ CPyL3: ;
     cpy_r_r37 = CPyObject_GetAttr(cpy_r_r35, cpy_r_r36);
     if (unlikely(cpy_r_r37 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
+        goto CPyL177;
     }
     if (likely(PyTuple_Check(cpy_r_r37)))
         cpy_r_r38 = cpy_r_r37;
     else {
         CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "<module>", 24, CPyStatic_globals, "tuple", cpy_r_r37);
-        goto CPyL173;
+        goto CPyL177;
     }
     cpy_r_r39.f0 = 6;
     cpy_r_r39.f1 = 22;
     cpy_r_r40 = PyTuple_New(2);
     if (unlikely(cpy_r_r40 == NULL))
         CPyError_OutOfMemory();
-    PyObject *__tmp50 = CPyTagged_StealAsObject(cpy_r_r39.f0);
-    PyTuple_SET_ITEM(cpy_r_r40, 0, __tmp50);
-    PyObject *__tmp51 = CPyTagged_StealAsObject(cpy_r_r39.f1);
-    PyTuple_SET_ITEM(cpy_r_r40, 1, __tmp51);
+    PyObject *__tmp49 = CPyTagged_StealAsObject(cpy_r_r39.f0);
+    PyTuple_SET_ITEM(cpy_r_r40, 0, __tmp49);
+    PyObject *__tmp50 = CPyTagged_StealAsObject(cpy_r_r39.f1);
+    PyTuple_SET_ITEM(cpy_r_r40, 1, __tmp50);
     cpy_r_r41 = PyObject_RichCompare(cpy_r_r38, cpy_r_r40, 5);
     CPy_DECREF(cpy_r_r38);
     CPy_DECREF(cpy_r_r40);
     if (unlikely(cpy_r_r41 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
+        goto CPyL177;
     }
     if (unlikely(!PyBool_Check(cpy_r_r41))) {
         CPy_TypeError("bool", cpy_r_r41); cpy_r_r42 = 2;
@@ -13578,7 +13564,7 @@ CPyL3: ;
     CPy_DECREF(cpy_r_r41);
     if (unlikely(cpy_r_r42 == 2)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
+        goto CPyL177;
     }
     if (!cpy_r_r42) goto CPyL15;
     cpy_r_r43 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* ('Self',) */
@@ -13587,7 +13573,7 @@ CPyL3: ;
     cpy_r_r46 = CPyImport_ImportFromMany(cpy_r_r44, cpy_r_r43, cpy_r_r43, cpy_r_r45);
     if (unlikely(cpy_r_r46 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
+        goto CPyL177;
     }
     CPyModule_typing = cpy_r_r46;
     CPy_INCREF(CPyModule_typing);
@@ -13598,7 +13584,7 @@ CPyL15: ;
     cpy_r_r47 = 0;
     if (unlikely(!cpy_r_r47)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
+        goto CPyL177;
     }
     CPy_Unreachable();
 CPyL17: ;
@@ -13607,29 +13593,29 @@ CPyL17: ;
     cpy_r_r50 = CPyObject_GetAttr(cpy_r_r48, cpy_r_r49);
     if (unlikely(cpy_r_r50 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
+        goto CPyL177;
     }
     if (likely(PyTuple_Check(cpy_r_r50)))
         cpy_r_r51 = cpy_r_r50;
     else {
         CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "<module>", 29, CPyStatic_globals, "tuple", cpy_r_r50);
-        goto CPyL173;
+        goto CPyL177;
     }
     cpy_r_r52.f0 = 6;
     cpy_r_r52.f1 = 28;
     cpy_r_r53 = PyTuple_New(2);
     if (unlikely(cpy_r_r53 == NULL))
         CPyError_OutOfMemory();
-    PyObject *__tmp52 = CPyTagged_StealAsObject(cpy_r_r52.f0);
-    PyTuple_SET_ITEM(cpy_r_r53, 0, __tmp52);
-    PyObject *__tmp53 = CPyTagged_StealAsObject(cpy_r_r52.f1);
-    PyTuple_SET_ITEM(cpy_r_r53, 1, __tmp53);
+    PyObject *__tmp51 = CPyTagged_StealAsObject(cpy_r_r52.f0);
+    PyTuple_SET_ITEM(cpy_r_r53, 0, __tmp51);
+    PyObject *__tmp52 = CPyTagged_StealAsObject(cpy_r_r52.f1);
+    PyTuple_SET_ITEM(cpy_r_r53, 1, __tmp52);
     cpy_r_r54 = PyObject_RichCompare(cpy_r_r51, cpy_r_r53, 0);
     CPy_DECREF(cpy_r_r51);
     CPy_DECREF(cpy_r_r53);
     if (unlikely(cpy_r_r54 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
+        goto CPyL177;
     }
     if (unlikely(!PyBool_Check(cpy_r_r54))) {
         CPy_TypeError("bool", cpy_r_r54); cpy_r_r55 = 2;
@@ -13638,25 +13624,25 @@ CPyL17: ;
     CPy_DECREF(cpy_r_r54);
     if (unlikely(cpy_r_r55 == 2)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
+        goto CPyL177;
     }
     if (!cpy_r_r55) goto CPyL24;
     PyErr_SetString(PyExc_RuntimeError, "Reached allegedly unreachable code!");
     cpy_r_r56 = 0;
     if (unlikely(!cpy_r_r56)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
+        goto CPyL177;
     }
     CPy_Unreachable();
 CPyL24: ;
-    cpy_r_r57 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '2.0.5.2' */
+    cpy_r_r57 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '2.0.5.3' */
     cpy_r_r58 = CPyStatic_globals;
     cpy_r_r59 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__version__' */
     cpy_r_r60 = CPyDict_SetItem(cpy_r_r58, cpy_r_r59, cpy_r_r57);
     cpy_r_r61 = cpy_r_r60 >= 0;
     if (unlikely(!cpy_r_r61)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
+        goto CPyL177;
     }
     cpy_r_r62 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'alru_cache' */
     CPy_INCREF(cpy_r_r62);
@@ -13666,312 +13652,307 @@ CPyL24: ;
     cpy_r_r66 = PyTuple_New(1);
     if (unlikely(cpy_r_r66 == NULL))
         CPyError_OutOfMemory();
-    PyObject *__tmp54 = cpy_r_r63.f0;
-    PyTuple_SET_ITEM(cpy_r_r66, 0, __tmp54);
+    PyObject *__tmp53 = cpy_r_r63.f0;
+    PyTuple_SET_ITEM(cpy_r_r66, 0, __tmp53);
     cpy_r_r67 = CPyDict_SetItem(cpy_r_r64, cpy_r_r65, cpy_r_r66);
     CPy_DECREF(cpy_r_r66);
     cpy_r_r68 = cpy_r_r67 >= 0;
     if (unlikely(!cpy_r_r68)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
+        goto CPyL177;
     }
-    cpy_r_r69 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_T' */
-    cpy_r_r70 = CPyStatic_globals;
-    cpy_r_r71 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'TypeVar' */
-    cpy_r_r72 = CPyDict_GetItem(cpy_r_r70, cpy_r_r71);
-    if (unlikely(cpy_r_r72 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
-    }
-    PyObject *cpy_r_r73[1] = {cpy_r_r69};
-    cpy_r_r74 = (PyObject **)&cpy_r_r73;
-    cpy_r_r75 = PyObject_Vectorcall(cpy_r_r72, cpy_r_r74, 1, 0);
-    CPy_DECREF(cpy_r_r72);
-    if (unlikely(cpy_r_r75 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
-    }
-    cpy_r_r76 = CPyStatic_globals;
-    cpy_r_r77 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_T' */
-    cpy_r_r78 = CPyDict_SetItem(cpy_r_r76, cpy_r_r77, cpy_r_r75);
-    CPy_DECREF(cpy_r_r75);
-    cpy_r_r79 = cpy_r_r78 >= 0;
-    if (unlikely(!cpy_r_r79)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
-    }
-    cpy_r_r80 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_R' */
-    cpy_r_r81 = CPyStatic_globals;
-    cpy_r_r82 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'TypeVar' */
-    cpy_r_r83 = CPyDict_GetItem(cpy_r_r81, cpy_r_r82);
-    if (unlikely(cpy_r_r83 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
-    }
-    PyObject *cpy_r_r84[1] = {cpy_r_r80};
-    cpy_r_r85 = (PyObject **)&cpy_r_r84;
-    cpy_r_r86 = PyObject_Vectorcall(cpy_r_r83, cpy_r_r85, 1, 0);
-    CPy_DECREF(cpy_r_r83);
-    if (unlikely(cpy_r_r86 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
-    }
-    cpy_r_r87 = CPyStatic_globals;
-    cpy_r_r88 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_R' */
-    cpy_r_r89 = CPyDict_SetItem(cpy_r_r87, cpy_r_r88, cpy_r_r86);
-    CPy_DECREF(cpy_r_r86);
-    cpy_r_r90 = cpy_r_r89 >= 0;
-    if (unlikely(!cpy_r_r90)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
-    }
-    cpy_r_r91 = CPyStatic_globals;
-    cpy_r_r92 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'Coroutine' */
-    cpy_r_r93 = CPyDict_GetItem(cpy_r_r91, cpy_r_r92);
-    if (unlikely(cpy_r_r93 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
-    }
-    cpy_r_r94 = CPyStatic_globals;
-    cpy_r_r95 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'Any' */
-    cpy_r_r96 = CPyDict_GetItem(cpy_r_r94, cpy_r_r95);
-    if (unlikely(cpy_r_r96 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL174;
-    }
-    cpy_r_r97 = CPyStatic_globals;
-    cpy_r_r98 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'Any' */
-    cpy_r_r99 = CPyDict_GetItem(cpy_r_r97, cpy_r_r98);
-    if (unlikely(cpy_r_r99 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL175;
-    }
-    cpy_r_r100 = CPyStatic_globals;
-    cpy_r_r101 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_R' */
-    cpy_r_r102 = CPyDict_GetItem(cpy_r_r100, cpy_r_r101);
-    if (unlikely(cpy_r_r102 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL176;
-    }
-    cpy_r_r103.f0 = cpy_r_r96;
-    cpy_r_r103.f1 = cpy_r_r99;
-    cpy_r_r103.f2 = cpy_r_r102;
-    cpy_r_r104 = PyTuple_New(3);
-    if (unlikely(cpy_r_r104 == NULL))
-        CPyError_OutOfMemory();
-    PyObject *__tmp55 = cpy_r_r103.f0;
-    PyTuple_SET_ITEM(cpy_r_r104, 0, __tmp55);
-    PyObject *__tmp56 = cpy_r_r103.f1;
-    PyTuple_SET_ITEM(cpy_r_r104, 1, __tmp56);
-    PyObject *__tmp57 = cpy_r_r103.f2;
-    PyTuple_SET_ITEM(cpy_r_r104, 2, __tmp57);
-    cpy_r_r105 = PyObject_GetItem(cpy_r_r93, cpy_r_r104);
-    CPy_DECREF(cpy_r_r93);
-    CPy_DECREF(cpy_r_r104);
-    if (unlikely(cpy_r_r105 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
-    }
-    cpy_r_r106 = CPyStatic_globals;
-    cpy_r_r107 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_Coro' */
-    cpy_r_r108 = CPyDict_SetItem(cpy_r_r106, cpy_r_r107, cpy_r_r105);
-    CPy_DECREF(cpy_r_r105);
-    cpy_r_r109 = cpy_r_r108 >= 0;
-    if (unlikely(!cpy_r_r109)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
-    }
-    cpy_r_r110 = CPyStatic_globals;
-    cpy_r_r111 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'Callable' */
-    cpy_r_r112 = CPyDict_GetItem(cpy_r_r110, cpy_r_r111);
-    if (unlikely(cpy_r_r112 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
-    }
-    cpy_r_r113 = (PyObject *)&_Py_EllipsisObject;
-    cpy_r_r114 = CPyStatic_globals;
-    cpy_r_r115 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_Coro' */
-    cpy_r_r116 = CPyDict_GetItem(cpy_r_r114, cpy_r_r115);
-    if (unlikely(cpy_r_r116 == NULL)) {
+    cpy_r_r69 = CPyModule_os;
+    cpy_r_r70 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'environ' */
+    cpy_r_r71 = CPyObject_GetAttr(cpy_r_r69, cpy_r_r70);
+    if (unlikely(cpy_r_r71 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
         goto CPyL177;
     }
-    cpy_r_r117 = CPyStatic_globals;
-    cpy_r_r118 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_R' */
-    cpy_r_r119 = CPyDict_GetItem(cpy_r_r117, cpy_r_r118);
-    if (unlikely(cpy_r_r119 == NULL)) {
+    cpy_r_r72 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'ASYNC_LRU_ALLOW_SYNC' */
+    cpy_r_r73 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'get' */
+    PyObject *cpy_r_r74[2] = {cpy_r_r71, cpy_r_r72};
+    cpy_r_r75 = (PyObject **)&cpy_r_r74;
+    cpy_r_r76 = PyObject_VectorcallMethod(cpy_r_r73, cpy_r_r75, 9223372036854775810ULL, 0);
+    if (unlikely(cpy_r_r76 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
         goto CPyL178;
     }
-    cpy_r_r120 = PyObject_GetItem(cpy_r_r116, cpy_r_r119);
-    CPy_DECREF(cpy_r_r116);
-    CPy_DECREF(cpy_r_r119);
-    if (unlikely(cpy_r_r120 == NULL)) {
+    CPy_DECREF(cpy_r_r71);
+    if (PyUnicode_Check(cpy_r_r76))
+        cpy_r_r77 = cpy_r_r76;
+    else {
+        cpy_r_r77 = NULL;
+    }
+    if (cpy_r_r77 != NULL) goto __LL54;
+    if (cpy_r_r76 == Py_None)
+        cpy_r_r77 = cpy_r_r76;
+    else {
+        cpy_r_r77 = NULL;
+    }
+    if (cpy_r_r77 != NULL) goto __LL54;
+    CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "<module>", 38, CPyStatic_globals, "str or None", cpy_r_r76);
+    goto CPyL177;
+__LL54: ;
+    CPyStatic_ALLOW_SYNC = cpy_r_r77;
+    CPy_INCREF(CPyStatic_ALLOW_SYNC);
+    cpy_r_r78 = CPyStatic_globals;
+    cpy_r_r79 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'ALLOW_SYNC' */
+    cpy_r_r80 = CPyDict_SetItem(cpy_r_r78, cpy_r_r79, cpy_r_r77);
+    CPy_DECREF(cpy_r_r77);
+    cpy_r_r81 = cpy_r_r80 >= 0;
+    if (unlikely(!cpy_r_r81)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
         goto CPyL177;
     }
-    CPy_INCREF(cpy_r_r113);
-    cpy_r_r121.f0 = cpy_r_r113;
-    cpy_r_r121.f1 = cpy_r_r120;
-    cpy_r_r122 = PyTuple_New(2);
-    if (unlikely(cpy_r_r122 == NULL))
-        CPyError_OutOfMemory();
-    PyObject *__tmp58 = cpy_r_r121.f0;
-    PyTuple_SET_ITEM(cpy_r_r122, 0, __tmp58);
-    PyObject *__tmp59 = cpy_r_r121.f1;
-    PyTuple_SET_ITEM(cpy_r_r122, 1, __tmp59);
-    cpy_r_r123 = PyObject_GetItem(cpy_r_r112, cpy_r_r122);
-    CPy_DECREF(cpy_r_r112);
-    CPy_DECREF(cpy_r_r122);
-    if (unlikely(cpy_r_r123 == NULL)) {
+    cpy_r_r82 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_T' */
+    cpy_r_r83 = CPyStatic_globals;
+    cpy_r_r84 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'TypeVar' */
+    cpy_r_r85 = CPyDict_GetItem(cpy_r_r83, cpy_r_r84);
+    if (unlikely(cpy_r_r85 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
+        goto CPyL177;
     }
-    cpy_r_r124 = CPyStatic_globals;
-    cpy_r_r125 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_CB' */
-    cpy_r_r126 = CPyDict_SetItem(cpy_r_r124, cpy_r_r125, cpy_r_r123);
-    CPy_DECREF(cpy_r_r123);
-    cpy_r_r127 = cpy_r_r126 >= 0;
-    if (unlikely(!cpy_r_r127)) {
+    PyObject *cpy_r_r86[1] = {cpy_r_r82};
+    cpy_r_r87 = (PyObject **)&cpy_r_r86;
+    cpy_r_r88 = PyObject_Vectorcall(cpy_r_r85, cpy_r_r87, 1, 0);
+    CPy_DECREF(cpy_r_r85);
+    if (unlikely(cpy_r_r88 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
+        goto CPyL177;
     }
-    cpy_r_r128 = CPyStatic_globals;
-    cpy_r_r129 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'Union' */
-    cpy_r_r130 = CPyDict_GetItem(cpy_r_r128, cpy_r_r129);
-    if (unlikely(cpy_r_r130 == NULL)) {
+    cpy_r_r89 = CPyStatic_globals;
+    cpy_r_r90 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_T' */
+    cpy_r_r91 = CPyDict_SetItem(cpy_r_r89, cpy_r_r90, cpy_r_r88);
+    CPy_DECREF(cpy_r_r88);
+    cpy_r_r92 = cpy_r_r91 >= 0;
+    if (unlikely(!cpy_r_r92)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
+        goto CPyL177;
     }
-    cpy_r_r131 = CPyStatic_globals;
-    cpy_r_r132 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_CB' */
-    cpy_r_r133 = CPyDict_GetItem(cpy_r_r131, cpy_r_r132);
-    if (unlikely(cpy_r_r133 == NULL)) {
+    cpy_r_r93 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_R' */
+    cpy_r_r94 = CPyStatic_globals;
+    cpy_r_r95 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'TypeVar' */
+    cpy_r_r96 = CPyDict_GetItem(cpy_r_r94, cpy_r_r95);
+    if (unlikely(cpy_r_r96 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL177;
+    }
+    PyObject *cpy_r_r97[1] = {cpy_r_r93};
+    cpy_r_r98 = (PyObject **)&cpy_r_r97;
+    cpy_r_r99 = PyObject_Vectorcall(cpy_r_r96, cpy_r_r98, 1, 0);
+    CPy_DECREF(cpy_r_r96);
+    if (unlikely(cpy_r_r99 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL177;
+    }
+    cpy_r_r100 = CPyStatic_globals;
+    cpy_r_r101 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_R' */
+    cpy_r_r102 = CPyDict_SetItem(cpy_r_r100, cpy_r_r101, cpy_r_r99);
+    CPy_DECREF(cpy_r_r99);
+    cpy_r_r103 = cpy_r_r102 >= 0;
+    if (unlikely(!cpy_r_r103)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL177;
+    }
+    cpy_r_r104 = CPyStatic_globals;
+    cpy_r_r105 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'Coroutine' */
+    cpy_r_r106 = CPyDict_GetItem(cpy_r_r104, cpy_r_r105);
+    if (unlikely(cpy_r_r106 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL177;
+    }
+    cpy_r_r107 = CPyStatic_globals;
+    cpy_r_r108 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'Any' */
+    cpy_r_r109 = CPyDict_GetItem(cpy_r_r107, cpy_r_r108);
+    if (unlikely(cpy_r_r109 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
         goto CPyL179;
     }
-    cpy_r_r134 = CPyStatic_globals;
-    cpy_r_r135 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_R' */
-    cpy_r_r136 = CPyDict_GetItem(cpy_r_r134, cpy_r_r135);
-    if (unlikely(cpy_r_r136 == NULL)) {
+    cpy_r_r110 = CPyStatic_globals;
+    cpy_r_r111 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'Any' */
+    cpy_r_r112 = CPyDict_GetItem(cpy_r_r110, cpy_r_r111);
+    if (unlikely(cpy_r_r112 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
         goto CPyL180;
     }
-    cpy_r_r137 = PyObject_GetItem(cpy_r_r133, cpy_r_r136);
-    CPy_DECREF(cpy_r_r133);
-    CPy_DECREF(cpy_r_r136);
-    if (unlikely(cpy_r_r137 == NULL)) {
+    cpy_r_r113 = CPyStatic_globals;
+    cpy_r_r114 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_R' */
+    cpy_r_r115 = CPyDict_GetItem(cpy_r_r113, cpy_r_r114);
+    if (unlikely(cpy_r_r115 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL179;
+        goto CPyL181;
     }
-    cpy_r_r138 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'functools.partial[_Coro[_R]]' */
-    cpy_r_r139 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'functools.partialmethod[_Coro[_R]]' */
-    CPy_INCREF(cpy_r_r138);
-    CPy_INCREF(cpy_r_r139);
-    cpy_r_r140.f0 = cpy_r_r137;
-    cpy_r_r140.f1 = cpy_r_r138;
-    cpy_r_r140.f2 = cpy_r_r139;
-    cpy_r_r141 = PyTuple_New(3);
-    if (unlikely(cpy_r_r141 == NULL))
+    cpy_r_r116.f0 = cpy_r_r109;
+    cpy_r_r116.f1 = cpy_r_r112;
+    cpy_r_r116.f2 = cpy_r_r115;
+    cpy_r_r117 = PyTuple_New(3);
+    if (unlikely(cpy_r_r117 == NULL))
         CPyError_OutOfMemory();
-    PyObject *__tmp60 = cpy_r_r140.f0;
-    PyTuple_SET_ITEM(cpy_r_r141, 0, __tmp60);
-    PyObject *__tmp61 = cpy_r_r140.f1;
-    PyTuple_SET_ITEM(cpy_r_r141, 1, __tmp61);
-    PyObject *__tmp62 = cpy_r_r140.f2;
-    PyTuple_SET_ITEM(cpy_r_r141, 2, __tmp62);
-    cpy_r_r142 = PyObject_GetItem(cpy_r_r130, cpy_r_r141);
-    CPy_DECREF(cpy_r_r130);
-    CPy_DECREF(cpy_r_r141);
-    if (unlikely(cpy_r_r142 == NULL)) {
+    PyObject *__tmp55 = cpy_r_r116.f0;
+    PyTuple_SET_ITEM(cpy_r_r117, 0, __tmp55);
+    PyObject *__tmp56 = cpy_r_r116.f1;
+    PyTuple_SET_ITEM(cpy_r_r117, 1, __tmp56);
+    PyObject *__tmp57 = cpy_r_r116.f2;
+    PyTuple_SET_ITEM(cpy_r_r117, 2, __tmp57);
+    cpy_r_r118 = PyObject_GetItem(cpy_r_r106, cpy_r_r117);
+    CPy_DECREF(cpy_r_r106);
+    CPy_DECREF(cpy_r_r117);
+    if (unlikely(cpy_r_r118 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
+        goto CPyL177;
     }
-    cpy_r_r143 = CPyStatic_globals;
-    cpy_r_r144 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_CBP' */
-    cpy_r_r145 = CPyDict_SetItem(cpy_r_r143, cpy_r_r144, cpy_r_r142);
-    CPy_DECREF(cpy_r_r142);
-    cpy_r_r146 = cpy_r_r145 >= 0;
-    if (unlikely(!cpy_r_r146)) {
+    cpy_r_r119 = CPyStatic_globals;
+    cpy_r_r120 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_Coro' */
+    cpy_r_r121 = CPyDict_SetItem(cpy_r_r119, cpy_r_r120, cpy_r_r118);
+    CPy_DECREF(cpy_r_r118);
+    cpy_r_r122 = cpy_r_r121 >= 0;
+    if (unlikely(!cpy_r_r122)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
+        goto CPyL177;
     }
-    cpy_r_r147 = CPyModule_sys;
-    cpy_r_r148 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'version_info' */
-    cpy_r_r149 = CPyObject_GetAttr(cpy_r_r147, cpy_r_r148);
+    cpy_r_r123 = CPyStatic_globals;
+    cpy_r_r124 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'Callable' */
+    cpy_r_r125 = CPyDict_GetItem(cpy_r_r123, cpy_r_r124);
+    if (unlikely(cpy_r_r125 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL177;
+    }
+    cpy_r_r126 = (PyObject *)&_Py_EllipsisObject;
+    cpy_r_r127 = CPyStatic_globals;
+    cpy_r_r128 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_Coro' */
+    cpy_r_r129 = CPyDict_GetItem(cpy_r_r127, cpy_r_r128);
+    if (unlikely(cpy_r_r129 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL182;
+    }
+    cpy_r_r130 = CPyStatic_globals;
+    cpy_r_r131 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_R' */
+    cpy_r_r132 = CPyDict_GetItem(cpy_r_r130, cpy_r_r131);
+    if (unlikely(cpy_r_r132 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL183;
+    }
+    cpy_r_r133 = PyObject_GetItem(cpy_r_r129, cpy_r_r132);
+    CPy_DECREF(cpy_r_r129);
+    CPy_DECREF(cpy_r_r132);
+    if (unlikely(cpy_r_r133 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL182;
+    }
+    CPy_INCREF(cpy_r_r126);
+    cpy_r_r134.f0 = cpy_r_r126;
+    cpy_r_r134.f1 = cpy_r_r133;
+    cpy_r_r135 = PyTuple_New(2);
+    if (unlikely(cpy_r_r135 == NULL))
+        CPyError_OutOfMemory();
+    PyObject *__tmp58 = cpy_r_r134.f0;
+    PyTuple_SET_ITEM(cpy_r_r135, 0, __tmp58);
+    PyObject *__tmp59 = cpy_r_r134.f1;
+    PyTuple_SET_ITEM(cpy_r_r135, 1, __tmp59);
+    cpy_r_r136 = PyObject_GetItem(cpy_r_r125, cpy_r_r135);
+    CPy_DECREF(cpy_r_r125);
+    CPy_DECREF(cpy_r_r135);
+    if (unlikely(cpy_r_r136 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL177;
+    }
+    cpy_r_r137 = CPyStatic_globals;
+    cpy_r_r138 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_CB' */
+    cpy_r_r139 = CPyDict_SetItem(cpy_r_r137, cpy_r_r138, cpy_r_r136);
+    CPy_DECREF(cpy_r_r136);
+    cpy_r_r140 = cpy_r_r139 >= 0;
+    if (unlikely(!cpy_r_r140)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL177;
+    }
+    cpy_r_r141 = CPyStatic_globals;
+    cpy_r_r142 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'Union' */
+    cpy_r_r143 = CPyDict_GetItem(cpy_r_r141, cpy_r_r142);
+    if (unlikely(cpy_r_r143 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL177;
+    }
+    cpy_r_r144 = CPyStatic_globals;
+    cpy_r_r145 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_CB' */
+    cpy_r_r146 = CPyDict_GetItem(cpy_r_r144, cpy_r_r145);
+    if (unlikely(cpy_r_r146 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL184;
+    }
+    cpy_r_r147 = CPyStatic_globals;
+    cpy_r_r148 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_R' */
+    cpy_r_r149 = CPyDict_GetItem(cpy_r_r147, cpy_r_r148);
     if (unlikely(cpy_r_r149 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
+        goto CPyL185;
     }
-    if (likely(PyTuple_Check(cpy_r_r149)))
-        cpy_r_r150 = cpy_r_r149;
-    else {
-        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "<module>", 44, CPyStatic_globals, "tuple", cpy_r_r149);
-        goto CPyL173;
+    cpy_r_r150 = PyObject_GetItem(cpy_r_r146, cpy_r_r149);
+    CPy_DECREF(cpy_r_r146);
+    CPy_DECREF(cpy_r_r149);
+    if (unlikely(cpy_r_r150 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL184;
     }
-    cpy_r_r151.f0 = 6;
-    cpy_r_r151.f1 = 24;
-    cpy_r_r152 = PyTuple_New(2);
-    if (unlikely(cpy_r_r152 == NULL))
+    cpy_r_r151 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'functools.partial[_Coro[_R]]' */
+    cpy_r_r152 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'functools.partialmethod[_Coro[_R]]' */
+    CPy_INCREF(cpy_r_r151);
+    CPy_INCREF(cpy_r_r152);
+    cpy_r_r153.f0 = cpy_r_r150;
+    cpy_r_r153.f1 = cpy_r_r151;
+    cpy_r_r153.f2 = cpy_r_r152;
+    cpy_r_r154 = PyTuple_New(3);
+    if (unlikely(cpy_r_r154 == NULL))
         CPyError_OutOfMemory();
-    PyObject *__tmp63 = CPyTagged_StealAsObject(cpy_r_r151.f0);
-    PyTuple_SET_ITEM(cpy_r_r152, 0, __tmp63);
-    PyObject *__tmp64 = CPyTagged_StealAsObject(cpy_r_r151.f1);
-    PyTuple_SET_ITEM(cpy_r_r152, 1, __tmp64);
-    cpy_r_r153 = PyObject_RichCompare(cpy_r_r150, cpy_r_r152, 5);
-    CPy_DECREF(cpy_r_r150);
-    CPy_DECREF(cpy_r_r152);
-    if (unlikely(cpy_r_r153 == NULL)) {
+    PyObject *__tmp60 = cpy_r_r153.f0;
+    PyTuple_SET_ITEM(cpy_r_r154, 0, __tmp60);
+    PyObject *__tmp61 = cpy_r_r153.f1;
+    PyTuple_SET_ITEM(cpy_r_r154, 1, __tmp61);
+    PyObject *__tmp62 = cpy_r_r153.f2;
+    PyTuple_SET_ITEM(cpy_r_r154, 2, __tmp62);
+    cpy_r_r155 = PyObject_GetItem(cpy_r_r143, cpy_r_r154);
+    CPy_DECREF(cpy_r_r143);
+    CPy_DECREF(cpy_r_r154);
+    if (unlikely(cpy_r_r155 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
+        goto CPyL177;
     }
-    if (unlikely(!PyBool_Check(cpy_r_r153))) {
-        CPy_TypeError("bool", cpy_r_r153); cpy_r_r154 = 2;
-    } else
-        cpy_r_r154 = cpy_r_r153 == Py_True;
-    CPy_DECREF(cpy_r_r153);
-    if (unlikely(cpy_r_r154 == 2)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
-    }
-    CPyStatic__PYTHON_GTE_312 = cpy_r_r154;
-    cpy_r_r155 = CPyStatic_globals;
-    cpy_r_r156 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_PYTHON_GTE_312' */
-    cpy_r_r157 = cpy_r_r154 ? Py_True : Py_False;
-    cpy_r_r158 = CPyDict_SetItem(cpy_r_r155, cpy_r_r156, cpy_r_r157);
+    cpy_r_r156 = CPyStatic_globals;
+    cpy_r_r157 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_CBP' */
+    cpy_r_r158 = CPyDict_SetItem(cpy_r_r156, cpy_r_r157, cpy_r_r155);
+    CPy_DECREF(cpy_r_r155);
     cpy_r_r159 = cpy_r_r158 >= 0;
     if (unlikely(!cpy_r_r159)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
+        goto CPyL177;
     }
     cpy_r_r160 = CPyModule_sys;
     cpy_r_r161 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'version_info' */
     cpy_r_r162 = CPyObject_GetAttr(cpy_r_r160, cpy_r_r161);
     if (unlikely(cpy_r_r162 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
+        goto CPyL177;
     }
     if (likely(PyTuple_Check(cpy_r_r162)))
         cpy_r_r163 = cpy_r_r162;
     else {
-        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "<module>", 45, CPyStatic_globals, "tuple", cpy_r_r162);
-        goto CPyL173;
+        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "<module>", 47, CPyStatic_globals, "tuple", cpy_r_r162);
+        goto CPyL177;
     }
     cpy_r_r164.f0 = 6;
-    cpy_r_r164.f1 = 28;
+    cpy_r_r164.f1 = 24;
     cpy_r_r165 = PyTuple_New(2);
     if (unlikely(cpy_r_r165 == NULL))
         CPyError_OutOfMemory();
-    PyObject *__tmp65 = CPyTagged_StealAsObject(cpy_r_r164.f0);
-    PyTuple_SET_ITEM(cpy_r_r165, 0, __tmp65);
-    PyObject *__tmp66 = CPyTagged_StealAsObject(cpy_r_r164.f1);
-    PyTuple_SET_ITEM(cpy_r_r165, 1, __tmp66);
-    cpy_r_r166 = PyObject_RichCompare(cpy_r_r163, cpy_r_r165, 0);
+    PyObject *__tmp63 = CPyTagged_StealAsObject(cpy_r_r164.f0);
+    PyTuple_SET_ITEM(cpy_r_r165, 0, __tmp63);
+    PyObject *__tmp64 = CPyTagged_StealAsObject(cpy_r_r164.f1);
+    PyTuple_SET_ITEM(cpy_r_r165, 1, __tmp64);
+    cpy_r_r166 = PyObject_RichCompare(cpy_r_r163, cpy_r_r165, 5);
     CPy_DECREF(cpy_r_r163);
     CPy_DECREF(cpy_r_r165);
     if (unlikely(cpy_r_r166 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
+        goto CPyL177;
     }
     if (unlikely(!PyBool_Check(cpy_r_r166))) {
         CPy_TypeError("bool", cpy_r_r166); cpy_r_r167 = 2;
@@ -13980,958 +13961,1009 @@ CPyL24: ;
     CPy_DECREF(cpy_r_r166);
     if (unlikely(cpy_r_r167 == 2)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
+        goto CPyL177;
     }
-    CPyStatic__PYTHON_LT_314 = cpy_r_r167;
+    CPyStatic__PYTHON_GTE_312 = cpy_r_r167;
     cpy_r_r168 = CPyStatic_globals;
-    cpy_r_r169 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_PYTHON_LT_314' */
+    cpy_r_r169 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_PYTHON_GTE_312' */
     cpy_r_r170 = cpy_r_r167 ? Py_True : Py_False;
     cpy_r_r171 = CPyDict_SetItem(cpy_r_r168, cpy_r_r169, cpy_r_r170);
     cpy_r_r172 = cpy_r_r171 >= 0;
     if (unlikely(!cpy_r_r172)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
+        goto CPyL177;
     }
-    cpy_r_r173 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_CacheInfo' */
-    cpy_r_r174 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'hits' */
-    cpy_r_r175 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'misses' */
-    cpy_r_r176 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'maxsize' */
-    cpy_r_r177 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'currsize' */
-    cpy_r_r178 = PyList_New(4);
-    if (unlikely(cpy_r_r178 == NULL)) {
+    cpy_r_r173 = CPyModule_sys;
+    cpy_r_r174 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'version_info' */
+    cpy_r_r175 = CPyObject_GetAttr(cpy_r_r173, cpy_r_r174);
+    if (unlikely(cpy_r_r175 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
+        goto CPyL177;
     }
-    cpy_r_r179 = (CPyPtr)&((PyListObject *)cpy_r_r178)->ob_item;
-    cpy_r_r180 = *(CPyPtr *)cpy_r_r179;
-    CPy_INCREF(cpy_r_r174);
-    *(PyObject * *)cpy_r_r180 = cpy_r_r174;
-    CPy_INCREF(cpy_r_r175);
-    cpy_r_r181 = cpy_r_r180 + 8;
-    *(PyObject * *)cpy_r_r181 = cpy_r_r175;
-    CPy_INCREF(cpy_r_r176);
-    cpy_r_r182 = cpy_r_r180 + 16;
-    *(PyObject * *)cpy_r_r182 = cpy_r_r176;
-    CPy_INCREF(cpy_r_r177);
-    cpy_r_r183 = cpy_r_r180 + 24;
-    *(PyObject * *)cpy_r_r183 = cpy_r_r177;
-    cpy_r_r184 = CPyStatic_globals;
-    cpy_r_r185 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'namedtuple' */
-    cpy_r_r186 = CPyDict_GetItem(cpy_r_r184, cpy_r_r185);
-    if (unlikely(cpy_r_r186 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL181;
-    }
-    PyObject *cpy_r_r187[2] = {cpy_r_r173, cpy_r_r178};
-    cpy_r_r188 = (PyObject **)&cpy_r_r187;
-    cpy_r_r189 = PyObject_Vectorcall(cpy_r_r186, cpy_r_r188, 2, 0);
-    CPy_DECREF(cpy_r_r186);
-    if (unlikely(cpy_r_r189 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL181;
-    }
-    CPy_DECREF_NO_IMM(cpy_r_r178);
-    cpy_r_r190 = CPyStatic_globals;
-    cpy_r_r191 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_CacheInfo' */
-    cpy_r_r192 = CPyDict_SetItem(cpy_r_r190, cpy_r_r191, cpy_r_r189);
-    CPy_DECREF(cpy_r_r189);
-    cpy_r_r193 = cpy_r_r192 >= 0;
-    if (unlikely(!cpy_r_r193)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
-    }
-    cpy_r_r194 = CPyModule_asyncio;
-    cpy_r_r195 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'CancelledError' */
-    cpy_r_r196 = CPyObject_GetAttr(cpy_r_r194, cpy_r_r195);
-    if (unlikely(cpy_r_r196 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
-    }
-    CPyStatic_CancelledError = cpy_r_r196;
-    CPy_INCREF(CPyStatic_CancelledError);
-    cpy_r_r197 = CPyStatic_globals;
-    cpy_r_r198 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'CancelledError' */
-    cpy_r_r199 = CPyDict_SetItem(cpy_r_r197, cpy_r_r198, cpy_r_r196);
-    CPy_DECREF(cpy_r_r196);
-    cpy_r_r200 = cpy_r_r199 >= 0;
-    if (unlikely(!cpy_r_r200)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
-    }
-    cpy_r_r201 = CPyModule_functools;
-    cpy_r_r202 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'partial' */
-    cpy_r_r203 = CPyObject_GetAttr(cpy_r_r201, cpy_r_r202);
-    if (unlikely(cpy_r_r203 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
-    }
-    CPyStatic_partial = cpy_r_r203;
-    CPy_INCREF(CPyStatic_partial);
-    cpy_r_r204 = CPyStatic_globals;
-    cpy_r_r205 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'partial' */
-    cpy_r_r206 = CPyDict_SetItem(cpy_r_r204, cpy_r_r205, cpy_r_r203);
-    CPy_DECREF(cpy_r_r203);
-    cpy_r_r207 = cpy_r_r206 >= 0;
-    if (unlikely(!cpy_r_r207)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
-    }
-    cpy_r_r208 = CPyModule_functools;
-    cpy_r_r209 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'partialmethod' */
-    cpy_r_r210 = CPyObject_GetAttr(cpy_r_r208, cpy_r_r209);
-    if (unlikely(cpy_r_r210 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
-    }
-    CPyStatic_partialmethod = cpy_r_r210;
-    CPy_INCREF(CPyStatic_partialmethod);
-    cpy_r_r211 = CPyStatic_globals;
-    cpy_r_r212 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'partialmethod' */
-    cpy_r_r213 = CPyDict_SetItem(cpy_r_r211, cpy_r_r212, cpy_r_r210);
-    CPy_DECREF(cpy_r_r210);
-    cpy_r_r214 = cpy_r_r213 >= 0;
-    if (unlikely(!cpy_r_r214)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
-    }
-    cpy_r_r215 = CPyModule_asyncio;
-    cpy_r_r216 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'gather' */
-    cpy_r_r217 = CPyObject_GetAttr(cpy_r_r215, cpy_r_r216);
-    if (unlikely(cpy_r_r217 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
-    }
-    CPyStatic_gather = cpy_r_r217;
-    CPy_INCREF(CPyStatic_gather);
-    cpy_r_r218 = CPyStatic_globals;
-    cpy_r_r219 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'gather' */
-    cpy_r_r220 = CPyDict_SetItem(cpy_r_r218, cpy_r_r219, cpy_r_r217);
-    CPy_DECREF(cpy_r_r217);
-    cpy_r_r221 = cpy_r_r220 >= 0;
-    if (unlikely(!cpy_r_r221)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
-    }
-    cpy_r_r222 = CPyModule_asyncio;
-    cpy_r_r223 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'get_running_loop' */
-    cpy_r_r224 = CPyObject_GetAttr(cpy_r_r222, cpy_r_r223);
-    if (unlikely(cpy_r_r224 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
-    }
-    CPyStatic_get_running_loop = cpy_r_r224;
-    CPy_INCREF(CPyStatic_get_running_loop);
-    cpy_r_r225 = CPyStatic_globals;
-    cpy_r_r226 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'get_running_loop' */
-    cpy_r_r227 = CPyDict_SetItem(cpy_r_r225, cpy_r_r226, cpy_r_r224);
-    CPy_DECREF(cpy_r_r224);
-    cpy_r_r228 = cpy_r_r227 >= 0;
-    if (unlikely(!cpy_r_r228)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
-    }
-    cpy_r_r229 = CPyModule_asyncio;
-    cpy_r_r230 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'shield' */
-    cpy_r_r231 = CPyObject_GetAttr(cpy_r_r229, cpy_r_r230);
-    if (unlikely(cpy_r_r231 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
-    }
-    CPyStatic_shield = cpy_r_r231;
-    CPy_INCREF(CPyStatic_shield);
-    cpy_r_r232 = CPyStatic_globals;
-    cpy_r_r233 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'shield' */
-    cpy_r_r234 = CPyDict_SetItem(cpy_r_r232, cpy_r_r233, cpy_r_r231);
-    CPy_DECREF(cpy_r_r231);
-    cpy_r_r235 = cpy_r_r234 >= 0;
-    if (unlikely(!cpy_r_r235)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
-    }
-    cpy_r_r236 = CPyStatic__PYTHON_GTE_312;
-    if (likely(cpy_r_r236 != 2)) goto CPyL79;
-    PyErr_SetString(PyExc_NameError, "value for final name \"_PYTHON_GTE_312\" was not set");
-    cpy_r_r237 = 0;
-    if (unlikely(!cpy_r_r237)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
-    }
-    CPy_Unreachable();
-CPyL79: ;
-    if (!cpy_r_r236) goto CPyL82;
-    cpy_r_r238 = CPyModule_inspect;
-    cpy_r_r239 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'markcoroutinefunction' */
-    cpy_r_r240 = CPyObject_GetAttr(cpy_r_r238, cpy_r_r239);
-    if (unlikely(cpy_r_r240 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
-    }
-    cpy_r_r241 = cpy_r_r240;
-    goto CPyL83;
-CPyL82: ;
-    cpy_r_r242 = Py_None;
-    cpy_r_r241 = cpy_r_r242;
-CPyL83: ;
-    CPyStatic_markcoroutinefunction = cpy_r_r241;
-    CPy_INCREF(CPyStatic_markcoroutinefunction);
-    cpy_r_r243 = CPyStatic_globals;
-    cpy_r_r244 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'markcoroutinefunction' */
-    cpy_r_r245 = CPyDict_SetItem(cpy_r_r243, cpy_r_r244, cpy_r_r241);
-    CPy_DECREF(cpy_r_r241);
-    cpy_r_r246 = cpy_r_r245 >= 0;
-    if (unlikely(!cpy_r_r246)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
-    }
-    cpy_r_r247 = CPyModule_typing;
-    cpy_r_r248 = (PyObject *)&_Py_NoneStruct;
-    cpy_r_r249 = cpy_r_r247 != cpy_r_r248;
-    if (cpy_r_r249) goto CPyL87;
-    cpy_r_r250 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'typing' */
-    cpy_r_r251 = PyImport_Import(cpy_r_r250);
-    if (unlikely(cpy_r_r251 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
-    }
-    CPyModule_typing = cpy_r_r251;
-    CPy_INCREF(CPyModule_typing);
-    CPy_DECREF(cpy_r_r251);
-CPyL87: ;
-    cpy_r_r252 = PyImport_GetModuleDict();
-    cpy_r_r253 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'typing' */
-    cpy_r_r254 = CPyDict_GetItem(cpy_r_r252, cpy_r_r253);
-    if (unlikely(cpy_r_r254 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
-    }
-    cpy_r_r255 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_TypedDict' */
-    cpy_r_r256 = CPyObject_GetAttr(cpy_r_r254, cpy_r_r255);
-    CPy_DECREF(cpy_r_r254);
-    if (unlikely(cpy_r_r256 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
-    }
-    cpy_r_r257 = PyTuple_Pack(1, cpy_r_r256);
-    CPy_DECREF(cpy_r_r256);
-    if (unlikely(cpy_r_r257 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
-    }
-    cpy_r_r258 = CPyModule_typing;
-    cpy_r_r259 = (PyObject *)&_Py_NoneStruct;
-    cpy_r_r260 = cpy_r_r258 != cpy_r_r259;
-    if (cpy_r_r260) goto CPyL93;
-    cpy_r_r261 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'typing' */
-    cpy_r_r262 = PyImport_Import(cpy_r_r261);
-    if (unlikely(cpy_r_r262 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL182;
-    }
-    CPyModule_typing = cpy_r_r262;
-    CPy_INCREF(CPyModule_typing);
-    CPy_DECREF(cpy_r_r262);
-CPyL93: ;
-    cpy_r_r263 = PyImport_GetModuleDict();
-    cpy_r_r264 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'typing' */
-    cpy_r_r265 = CPyDict_GetItem(cpy_r_r263, cpy_r_r264);
-    if (unlikely(cpy_r_r265 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL182;
-    }
-    cpy_r_r266 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_TypedDictMeta' */
-    cpy_r_r267 = CPyObject_GetAttr(cpy_r_r265, cpy_r_r266);
-    CPy_DECREF(cpy_r_r265);
-    if (unlikely(cpy_r_r267 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL182;
-    }
-    cpy_r_r268 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__prepare__' */
-    cpy_r_r269 = PyObject_HasAttr(cpy_r_r267, cpy_r_r268);
-    if (!cpy_r_r269) goto CPyL100;
-    cpy_r_r270 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_CacheParameters' */
-    cpy_r_r271 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__prepare__' */
-    cpy_r_r272 = CPyObject_GetAttr(cpy_r_r267, cpy_r_r271);
-    if (unlikely(cpy_r_r272 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL183;
-    }
-    PyObject *cpy_r_r273[2] = {cpy_r_r270, cpy_r_r257};
-    cpy_r_r274 = (PyObject **)&cpy_r_r273;
-    cpy_r_r275 = PyObject_Vectorcall(cpy_r_r272, cpy_r_r274, 2, 0);
-    CPy_DECREF(cpy_r_r272);
-    if (unlikely(cpy_r_r275 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL183;
-    }
-    if (likely(PyDict_Check(cpy_r_r275)))
-        cpy_r_r276 = cpy_r_r275;
+    if (likely(PyTuple_Check(cpy_r_r175)))
+        cpy_r_r176 = cpy_r_r175;
     else {
-        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "<module>", 62, CPyStatic_globals, "dict", cpy_r_r275);
-        goto CPyL183;
+        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "<module>", 48, CPyStatic_globals, "tuple", cpy_r_r175);
+        goto CPyL177;
     }
-    cpy_r_r277 = cpy_r_r276;
-    goto CPyL102;
-CPyL100: ;
-    cpy_r_r278 = PyDict_New();
-    if (unlikely(cpy_r_r278 == NULL)) {
+    cpy_r_r177.f0 = 6;
+    cpy_r_r177.f1 = 28;
+    cpy_r_r178 = PyTuple_New(2);
+    if (unlikely(cpy_r_r178 == NULL))
+        CPyError_OutOfMemory();
+    PyObject *__tmp65 = CPyTagged_StealAsObject(cpy_r_r177.f0);
+    PyTuple_SET_ITEM(cpy_r_r178, 0, __tmp65);
+    PyObject *__tmp66 = CPyTagged_StealAsObject(cpy_r_r177.f1);
+    PyTuple_SET_ITEM(cpy_r_r178, 1, __tmp66);
+    cpy_r_r179 = PyObject_RichCompare(cpy_r_r176, cpy_r_r178, 0);
+    CPy_DECREF(cpy_r_r176);
+    CPy_DECREF(cpy_r_r178);
+    if (unlikely(cpy_r_r179 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL183;
+        goto CPyL177;
     }
-    cpy_r_r277 = cpy_r_r278;
-CPyL102: ;
-    cpy_r_r279 = PyDict_New();
-    if (unlikely(cpy_r_r279 == NULL)) {
+    if (unlikely(!PyBool_Check(cpy_r_r179))) {
+        CPy_TypeError("bool", cpy_r_r179); cpy_r_r180 = 2;
+    } else
+        cpy_r_r180 = cpy_r_r179 == Py_True;
+    CPy_DECREF(cpy_r_r179);
+    if (unlikely(cpy_r_r180 == 2)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL184;
+        goto CPyL177;
     }
-    cpy_r_r280 = (PyObject *)&PyBool_Type;
-    cpy_r_r281 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'typed' */
-    cpy_r_r282 = PyDict_SetItem(cpy_r_r279, cpy_r_r281, cpy_r_r280);
-    cpy_r_r283 = cpy_r_r282 >= 0;
-    if (unlikely(!cpy_r_r283)) {
+    CPyStatic__PYTHON_LT_314 = cpy_r_r180;
+    cpy_r_r181 = CPyStatic_globals;
+    cpy_r_r182 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_PYTHON_LT_314' */
+    cpy_r_r183 = cpy_r_r180 ? Py_True : Py_False;
+    cpy_r_r184 = CPyDict_SetItem(cpy_r_r181, cpy_r_r182, cpy_r_r183);
+    cpy_r_r185 = cpy_r_r184 >= 0;
+    if (unlikely(!cpy_r_r185)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL185;
+        goto CPyL177;
     }
-    cpy_r_r284 = (PyObject *)&PyType_Type;
-    cpy_r_r285 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'maxsize' */
-    cpy_r_r286 = PyDict_SetItem(cpy_r_r279, cpy_r_r285, cpy_r_r284);
-    cpy_r_r287 = cpy_r_r286 >= 0;
-    if (unlikely(!cpy_r_r287)) {
+    cpy_r_r186 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_CacheInfo' */
+    cpy_r_r187 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'hits' */
+    cpy_r_r188 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'misses' */
+    cpy_r_r189 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'maxsize' */
+    cpy_r_r190 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'currsize' */
+    cpy_r_r191 = PyList_New(4);
+    if (unlikely(cpy_r_r191 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL185;
+        goto CPyL177;
     }
-    cpy_r_r288 = (PyObject *)&PyLong_Type;
-    cpy_r_r289 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'tasks' */
-    cpy_r_r290 = PyDict_SetItem(cpy_r_r279, cpy_r_r289, cpy_r_r288);
-    cpy_r_r291 = cpy_r_r290 >= 0;
-    if (unlikely(!cpy_r_r291)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL185;
-    }
-    cpy_r_r292 = (PyObject *)&PyBool_Type;
-    cpy_r_r293 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'closed' */
-    cpy_r_r294 = PyDict_SetItem(cpy_r_r279, cpy_r_r293, cpy_r_r292);
-    cpy_r_r295 = cpy_r_r294 >= 0;
-    if (unlikely(!cpy_r_r295)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL185;
-    }
-    cpy_r_r296 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_CacheParameters' */
-    cpy_r_r297 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__annotations__' */
-    cpy_r_r298 = CPyDict_SetItem(cpy_r_r277, cpy_r_r297, cpy_r_r279);
-    CPy_DECREF(cpy_r_r279);
-    cpy_r_r299 = cpy_r_r298 >= 0;
-    if (unlikely(!cpy_r_r299)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL184;
-    }
-    cpy_r_r300 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'mypyc filler docstring' */
-    cpy_r_r301 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__doc__' */
-    cpy_r_r302 = CPyDict_SetItem(cpy_r_r277, cpy_r_r301, cpy_r_r300);
-    cpy_r_r303 = cpy_r_r302 >= 0;
-    if (unlikely(!cpy_r_r303)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL184;
-    }
-    cpy_r_r304 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'faster_async_lru' */
-    cpy_r_r305 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__module__' */
-    cpy_r_r306 = CPyDict_SetItem(cpy_r_r277, cpy_r_r305, cpy_r_r304);
-    cpy_r_r307 = cpy_r_r306 >= 0;
-    if (unlikely(!cpy_r_r307)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL184;
-    }
-    PyObject *cpy_r_r308[3] = {cpy_r_r296, cpy_r_r257, cpy_r_r277};
-    cpy_r_r309 = (PyObject **)&cpy_r_r308;
-    cpy_r_r310 = PyObject_Vectorcall(cpy_r_r267, cpy_r_r309, 3, 0);
-    CPy_DECREF(cpy_r_r267);
-    if (unlikely(cpy_r_r310 == NULL)) {
+    cpy_r_r192 = (CPyPtr)&((PyListObject *)cpy_r_r191)->ob_item;
+    cpy_r_r193 = *(CPyPtr *)cpy_r_r192;
+    CPy_INCREF(cpy_r_r187);
+    *(PyObject * *)cpy_r_r193 = cpy_r_r187;
+    CPy_INCREF(cpy_r_r188);
+    cpy_r_r194 = cpy_r_r193 + 8;
+    *(PyObject * *)cpy_r_r194 = cpy_r_r188;
+    CPy_INCREF(cpy_r_r189);
+    cpy_r_r195 = cpy_r_r193 + 16;
+    *(PyObject * *)cpy_r_r195 = cpy_r_r189;
+    CPy_INCREF(cpy_r_r190);
+    cpy_r_r196 = cpy_r_r193 + 24;
+    *(PyObject * *)cpy_r_r196 = cpy_r_r190;
+    cpy_r_r197 = CPyStatic_globals;
+    cpy_r_r198 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'namedtuple' */
+    cpy_r_r199 = CPyDict_GetItem(cpy_r_r197, cpy_r_r198);
+    if (unlikely(cpy_r_r199 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
         goto CPyL186;
     }
-    CPy_DECREF(cpy_r_r257);
-    CPy_DECREF(cpy_r_r277);
-    cpy_r_r311 = CPyStatic_globals;
-    cpy_r_r312 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'final' */
-    cpy_r_r313 = CPyDict_GetItem(cpy_r_r311, cpy_r_r312);
-    if (unlikely(cpy_r_r313 == NULL)) {
+    PyObject *cpy_r_r200[2] = {cpy_r_r186, cpy_r_r191};
+    cpy_r_r201 = (PyObject **)&cpy_r_r200;
+    cpy_r_r202 = PyObject_Vectorcall(cpy_r_r199, cpy_r_r201, 2, 0);
+    CPy_DECREF(cpy_r_r199);
+    if (unlikely(cpy_r_r202 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL186;
+    }
+    CPy_DECREF_NO_IMM(cpy_r_r191);
+    cpy_r_r203 = CPyStatic_globals;
+    cpy_r_r204 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_CacheInfo' */
+    cpy_r_r205 = CPyDict_SetItem(cpy_r_r203, cpy_r_r204, cpy_r_r202);
+    CPy_DECREF(cpy_r_r202);
+    cpy_r_r206 = cpy_r_r205 >= 0;
+    if (unlikely(!cpy_r_r206)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL177;
+    }
+    cpy_r_r207 = CPyModule_asyncio;
+    cpy_r_r208 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'CancelledError' */
+    cpy_r_r209 = CPyObject_GetAttr(cpy_r_r207, cpy_r_r208);
+    if (unlikely(cpy_r_r209 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL177;
+    }
+    CPyStatic_CancelledError = cpy_r_r209;
+    CPy_INCREF(CPyStatic_CancelledError);
+    cpy_r_r210 = CPyStatic_globals;
+    cpy_r_r211 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'CancelledError' */
+    cpy_r_r212 = CPyDict_SetItem(cpy_r_r210, cpy_r_r211, cpy_r_r209);
+    CPy_DECREF(cpy_r_r209);
+    cpy_r_r213 = cpy_r_r212 >= 0;
+    if (unlikely(!cpy_r_r213)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL177;
+    }
+    cpy_r_r214 = CPyModule_functools;
+    cpy_r_r215 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'partial' */
+    cpy_r_r216 = CPyObject_GetAttr(cpy_r_r214, cpy_r_r215);
+    if (unlikely(cpy_r_r216 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL177;
+    }
+    CPyStatic_partial = cpy_r_r216;
+    CPy_INCREF(CPyStatic_partial);
+    cpy_r_r217 = CPyStatic_globals;
+    cpy_r_r218 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'partial' */
+    cpy_r_r219 = CPyDict_SetItem(cpy_r_r217, cpy_r_r218, cpy_r_r216);
+    CPy_DECREF(cpy_r_r216);
+    cpy_r_r220 = cpy_r_r219 >= 0;
+    if (unlikely(!cpy_r_r220)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL177;
+    }
+    cpy_r_r221 = CPyModule_functools;
+    cpy_r_r222 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'partialmethod' */
+    cpy_r_r223 = CPyObject_GetAttr(cpy_r_r221, cpy_r_r222);
+    if (unlikely(cpy_r_r223 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL177;
+    }
+    CPyStatic_partialmethod = cpy_r_r223;
+    CPy_INCREF(CPyStatic_partialmethod);
+    cpy_r_r224 = CPyStatic_globals;
+    cpy_r_r225 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'partialmethod' */
+    cpy_r_r226 = CPyDict_SetItem(cpy_r_r224, cpy_r_r225, cpy_r_r223);
+    CPy_DECREF(cpy_r_r223);
+    cpy_r_r227 = cpy_r_r226 >= 0;
+    if (unlikely(!cpy_r_r227)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL177;
+    }
+    cpy_r_r228 = CPyModule_asyncio;
+    cpy_r_r229 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'gather' */
+    cpy_r_r230 = CPyObject_GetAttr(cpy_r_r228, cpy_r_r229);
+    if (unlikely(cpy_r_r230 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL177;
+    }
+    CPyStatic_gather = cpy_r_r230;
+    CPy_INCREF(CPyStatic_gather);
+    cpy_r_r231 = CPyStatic_globals;
+    cpy_r_r232 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'gather' */
+    cpy_r_r233 = CPyDict_SetItem(cpy_r_r231, cpy_r_r232, cpy_r_r230);
+    CPy_DECREF(cpy_r_r230);
+    cpy_r_r234 = cpy_r_r233 >= 0;
+    if (unlikely(!cpy_r_r234)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL177;
+    }
+    cpy_r_r235 = CPyModule_asyncio;
+    cpy_r_r236 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'get_running_loop' */
+    cpy_r_r237 = CPyObject_GetAttr(cpy_r_r235, cpy_r_r236);
+    if (unlikely(cpy_r_r237 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL177;
+    }
+    CPyStatic_get_running_loop = cpy_r_r237;
+    CPy_INCREF(CPyStatic_get_running_loop);
+    cpy_r_r238 = CPyStatic_globals;
+    cpy_r_r239 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'get_running_loop' */
+    cpy_r_r240 = CPyDict_SetItem(cpy_r_r238, cpy_r_r239, cpy_r_r237);
+    CPy_DECREF(cpy_r_r237);
+    cpy_r_r241 = cpy_r_r240 >= 0;
+    if (unlikely(!cpy_r_r241)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL177;
+    }
+    cpy_r_r242 = CPyModule_asyncio;
+    cpy_r_r243 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'shield' */
+    cpy_r_r244 = CPyObject_GetAttr(cpy_r_r242, cpy_r_r243);
+    if (unlikely(cpy_r_r244 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL177;
+    }
+    CPyStatic_shield = cpy_r_r244;
+    CPy_INCREF(CPyStatic_shield);
+    cpy_r_r245 = CPyStatic_globals;
+    cpy_r_r246 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'shield' */
+    cpy_r_r247 = CPyDict_SetItem(cpy_r_r245, cpy_r_r246, cpy_r_r244);
+    CPy_DECREF(cpy_r_r244);
+    cpy_r_r248 = cpy_r_r247 >= 0;
+    if (unlikely(!cpy_r_r248)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL177;
+    }
+    cpy_r_r249 = CPyStatic__PYTHON_GTE_312;
+    if (likely(cpy_r_r249 != 2)) goto CPyL83;
+    PyErr_SetString(PyExc_NameError, "value for final name \"_PYTHON_GTE_312\" was not set");
+    cpy_r_r250 = 0;
+    if (unlikely(!cpy_r_r250)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL177;
+    }
+    CPy_Unreachable();
+CPyL83: ;
+    if (!cpy_r_r249) goto CPyL86;
+    cpy_r_r251 = CPyModule_inspect;
+    cpy_r_r252 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'markcoroutinefunction' */
+    cpy_r_r253 = CPyObject_GetAttr(cpy_r_r251, cpy_r_r252);
+    if (unlikely(cpy_r_r253 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL177;
+    }
+    cpy_r_r254 = cpy_r_r253;
+    goto CPyL87;
+CPyL86: ;
+    cpy_r_r255 = Py_None;
+    cpy_r_r254 = cpy_r_r255;
+CPyL87: ;
+    CPyStatic_markcoroutinefunction = cpy_r_r254;
+    CPy_INCREF(CPyStatic_markcoroutinefunction);
+    cpy_r_r256 = CPyStatic_globals;
+    cpy_r_r257 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'markcoroutinefunction' */
+    cpy_r_r258 = CPyDict_SetItem(cpy_r_r256, cpy_r_r257, cpy_r_r254);
+    CPy_DECREF(cpy_r_r254);
+    cpy_r_r259 = cpy_r_r258 >= 0;
+    if (unlikely(!cpy_r_r259)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL177;
+    }
+    cpy_r_r260 = CPyModule_typing;
+    cpy_r_r261 = (PyObject *)&_Py_NoneStruct;
+    cpy_r_r262 = cpy_r_r260 != cpy_r_r261;
+    if (cpy_r_r262) goto CPyL91;
+    cpy_r_r263 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'typing' */
+    cpy_r_r264 = PyImport_Import(cpy_r_r263);
+    if (unlikely(cpy_r_r264 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL177;
+    }
+    CPyModule_typing = cpy_r_r264;
+    CPy_INCREF(CPyModule_typing);
+    CPy_DECREF(cpy_r_r264);
+CPyL91: ;
+    cpy_r_r265 = PyImport_GetModuleDict();
+    cpy_r_r266 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'typing' */
+    cpy_r_r267 = CPyDict_GetItem(cpy_r_r265, cpy_r_r266);
+    if (unlikely(cpy_r_r267 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL177;
+    }
+    cpy_r_r268 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_TypedDict' */
+    cpy_r_r269 = CPyObject_GetAttr(cpy_r_r267, cpy_r_r268);
+    CPy_DECREF(cpy_r_r267);
+    if (unlikely(cpy_r_r269 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL177;
+    }
+    cpy_r_r270 = PyTuple_Pack(1, cpy_r_r269);
+    CPy_DECREF(cpy_r_r269);
+    if (unlikely(cpy_r_r270 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL177;
+    }
+    cpy_r_r271 = CPyModule_typing;
+    cpy_r_r272 = (PyObject *)&_Py_NoneStruct;
+    cpy_r_r273 = cpy_r_r271 != cpy_r_r272;
+    if (cpy_r_r273) goto CPyL97;
+    cpy_r_r274 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'typing' */
+    cpy_r_r275 = PyImport_Import(cpy_r_r274);
+    if (unlikely(cpy_r_r275 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
         goto CPyL187;
     }
-    PyObject *cpy_r_r314[1] = {cpy_r_r310};
-    cpy_r_r315 = (PyObject **)&cpy_r_r314;
-    cpy_r_r316 = PyObject_Vectorcall(cpy_r_r313, cpy_r_r315, 1, 0);
-    CPy_DECREF(cpy_r_r313);
-    if (unlikely(cpy_r_r316 == NULL)) {
+    CPyModule_typing = cpy_r_r275;
+    CPy_INCREF(CPyModule_typing);
+    CPy_DECREF(cpy_r_r275);
+CPyL97: ;
+    cpy_r_r276 = PyImport_GetModuleDict();
+    cpy_r_r277 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'typing' */
+    cpy_r_r278 = CPyDict_GetItem(cpy_r_r276, cpy_r_r277);
+    if (unlikely(cpy_r_r278 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
         goto CPyL187;
     }
-    CPy_DECREF(cpy_r_r310);
-    CPyType__CacheParameters = (PyTypeObject *)cpy_r_r316;
-    CPy_INCREF(CPyType__CacheParameters);
-    cpy_r_r317 = CPyStatic_globals;
-    cpy_r_r318 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_CacheParameters' */
-    cpy_r_r319 = PyDict_SetItem(cpy_r_r317, cpy_r_r318, cpy_r_r316);
-    CPy_DECREF(cpy_r_r316);
-    cpy_r_r320 = cpy_r_r319 >= 0;
-    if (unlikely(!cpy_r_r320)) {
+    cpy_r_r279 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_TypedDictMeta' */
+    cpy_r_r280 = CPyObject_GetAttr(cpy_r_r278, cpy_r_r279);
+    CPy_DECREF(cpy_r_r278);
+    if (unlikely(cpy_r_r280 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
+        goto CPyL187;
     }
-    cpy_r_r321 = (PyObject *)CPyType__CacheParameters;
-    cpy_r_r322 = CPyStatic_globals;
-    cpy_r_r323 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'Generic' */
-    cpy_r_r324 = CPyDict_GetItem(cpy_r_r322, cpy_r_r323);
-    if (unlikely(cpy_r_r324 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
-    }
-    cpy_r_r325 = CPyStatic_globals;
-    cpy_r_r326 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_R' */
-    cpy_r_r327 = CPyDict_GetItem(cpy_r_r325, cpy_r_r326);
-    if (unlikely(cpy_r_r327 == NULL)) {
+    cpy_r_r281 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__prepare__' */
+    cpy_r_r282 = PyObject_HasAttr(cpy_r_r280, cpy_r_r281);
+    if (!cpy_r_r282) goto CPyL104;
+    cpy_r_r283 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_CacheParameters' */
+    cpy_r_r284 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__prepare__' */
+    cpy_r_r285 = CPyObject_GetAttr(cpy_r_r280, cpy_r_r284);
+    if (unlikely(cpy_r_r285 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
         goto CPyL188;
     }
-    cpy_r_r328 = PyObject_GetItem(cpy_r_r324, cpy_r_r327);
-    CPy_DECREF(cpy_r_r324);
-    CPy_DECREF(cpy_r_r327);
-    if (unlikely(cpy_r_r328 == NULL)) {
+    PyObject *cpy_r_r286[2] = {cpy_r_r283, cpy_r_r270};
+    cpy_r_r287 = (PyObject **)&cpy_r_r286;
+    cpy_r_r288 = PyObject_Vectorcall(cpy_r_r285, cpy_r_r287, 2, 0);
+    CPy_DECREF(cpy_r_r285);
+    if (unlikely(cpy_r_r288 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
+        goto CPyL188;
     }
-    cpy_r_r329 = PyTuple_Pack(1, cpy_r_r328);
-    CPy_DECREF(cpy_r_r328);
-    if (unlikely(cpy_r_r329 == NULL)) {
+    if (likely(PyDict_Check(cpy_r_r288)))
+        cpy_r_r289 = cpy_r_r288;
+    else {
+        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "<module>", 65, CPyStatic_globals, "dict", cpy_r_r288);
+        goto CPyL188;
+    }
+    cpy_r_r290 = cpy_r_r289;
+    goto CPyL106;
+CPyL104: ;
+    cpy_r_r291 = PyDict_New();
+    if (unlikely(cpy_r_r291 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
+        goto CPyL188;
     }
-    cpy_r_r330 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'faster_async_lru' */
-    cpy_r_r331 = (PyObject *)CPyType__CacheItem_template;
-    cpy_r_r332 = CPyType_FromTemplate(cpy_r_r331, cpy_r_r329, cpy_r_r330);
-    CPy_DECREF(cpy_r_r329);
-    if (unlikely(cpy_r_r332 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
-    }
-    cpy_r_r333 = CPyDef__CacheItem_trait_vtable_setup();
-    if (unlikely(cpy_r_r333 == 2)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", -1, CPyStatic_globals);
-        goto CPyL189;
-    }
-    cpy_r_r334 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__mypyc_attrs__' */
-    cpy_r_r335 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'task' */
-    cpy_r_r336 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'later_call' */
-    cpy_r_r337 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'waiters' */
-    cpy_r_r338 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__dict__' */
-    cpy_r_r339 = PyTuple_Pack(4, cpy_r_r335, cpy_r_r336, cpy_r_r337, cpy_r_r338);
-    if (unlikely(cpy_r_r339 == NULL)) {
+    cpy_r_r290 = cpy_r_r291;
+CPyL106: ;
+    cpy_r_r292 = PyDict_New();
+    if (unlikely(cpy_r_r292 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
         goto CPyL189;
     }
-    cpy_r_r340 = PyObject_SetAttr(cpy_r_r332, cpy_r_r334, cpy_r_r339);
-    CPy_DECREF(cpy_r_r339);
-    cpy_r_r341 = cpy_r_r340 >= 0;
-    if (unlikely(!cpy_r_r341)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL189;
-    }
-    CPyType__CacheItem = (PyTypeObject *)cpy_r_r332;
-    CPy_INCREF(CPyType__CacheItem);
-    cpy_r_r342 = CPyStatic_globals;
-    cpy_r_r343 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_CacheItem' */
-    cpy_r_r344 = PyDict_SetItem(cpy_r_r342, cpy_r_r343, cpy_r_r332);
-    CPy_DECREF(cpy_r_r332);
-    cpy_r_r345 = cpy_r_r344 >= 0;
-    if (unlikely(!cpy_r_r345)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
-    }
-    cpy_r_r346 = CPyStatic_globals;
-    cpy_r_r347 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'Generic' */
-    cpy_r_r348 = CPyDict_GetItem(cpy_r_r346, cpy_r_r347);
-    if (unlikely(cpy_r_r348 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
-    }
-    cpy_r_r349 = CPyStatic_globals;
-    cpy_r_r350 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_R' */
-    cpy_r_r351 = CPyDict_GetItem(cpy_r_r349, cpy_r_r350);
-    if (unlikely(cpy_r_r351 == NULL)) {
+    cpy_r_r293 = (PyObject *)&PyBool_Type;
+    cpy_r_r294 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'typed' */
+    cpy_r_r295 = PyDict_SetItem(cpy_r_r292, cpy_r_r294, cpy_r_r293);
+    cpy_r_r296 = cpy_r_r295 >= 0;
+    if (unlikely(!cpy_r_r296)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
         goto CPyL190;
     }
-    cpy_r_r352 = PyObject_GetItem(cpy_r_r348, cpy_r_r351);
-    CPy_DECREF(cpy_r_r348);
-    CPy_DECREF(cpy_r_r351);
-    if (unlikely(cpy_r_r352 == NULL)) {
+    cpy_r_r297 = (PyObject *)&PyType_Type;
+    cpy_r_r298 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'maxsize' */
+    cpy_r_r299 = PyDict_SetItem(cpy_r_r292, cpy_r_r298, cpy_r_r297);
+    cpy_r_r300 = cpy_r_r299 >= 0;
+    if (unlikely(!cpy_r_r300)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
+        goto CPyL190;
     }
-    cpy_r_r353 = PyTuple_Pack(1, cpy_r_r352);
-    CPy_DECREF(cpy_r_r352);
-    if (unlikely(cpy_r_r353 == NULL)) {
+    cpy_r_r301 = (PyObject *)&PyLong_Type;
+    cpy_r_r302 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'tasks' */
+    cpy_r_r303 = PyDict_SetItem(cpy_r_r292, cpy_r_r302, cpy_r_r301);
+    cpy_r_r304 = cpy_r_r303 >= 0;
+    if (unlikely(!cpy_r_r304)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
+        goto CPyL190;
     }
-    cpy_r_r354 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'faster_async_lru' */
-    cpy_r_r355 = (PyObject *)CPyType__LRUCacheWrapper_template;
-    cpy_r_r356 = CPyType_FromTemplate(cpy_r_r355, cpy_r_r353, cpy_r_r354);
-    CPy_DECREF(cpy_r_r353);
-    if (unlikely(cpy_r_r356 == NULL)) {
+    cpy_r_r305 = (PyObject *)&PyBool_Type;
+    cpy_r_r306 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'closed' */
+    cpy_r_r307 = PyDict_SetItem(cpy_r_r292, cpy_r_r306, cpy_r_r305);
+    cpy_r_r308 = cpy_r_r307 >= 0;
+    if (unlikely(!cpy_r_r308)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
+        goto CPyL190;
     }
-    cpy_r_r357 = CPyDef__LRUCacheWrapper_trait_vtable_setup();
-    if (unlikely(cpy_r_r357 == 2)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", -1, CPyStatic_globals);
+    cpy_r_r309 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_CacheParameters' */
+    cpy_r_r310 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__annotations__' */
+    cpy_r_r311 = CPyDict_SetItem(cpy_r_r290, cpy_r_r310, cpy_r_r292);
+    CPy_DECREF(cpy_r_r292);
+    cpy_r_r312 = cpy_r_r311 >= 0;
+    if (unlikely(!cpy_r_r312)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL189;
+    }
+    cpy_r_r313 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'mypyc filler docstring' */
+    cpy_r_r314 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__doc__' */
+    cpy_r_r315 = CPyDict_SetItem(cpy_r_r290, cpy_r_r314, cpy_r_r313);
+    cpy_r_r316 = cpy_r_r315 >= 0;
+    if (unlikely(!cpy_r_r316)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL189;
+    }
+    cpy_r_r317 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'faster_async_lru' */
+    cpy_r_r318 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__module__' */
+    cpy_r_r319 = CPyDict_SetItem(cpy_r_r290, cpy_r_r318, cpy_r_r317);
+    cpy_r_r320 = cpy_r_r319 >= 0;
+    if (unlikely(!cpy_r_r320)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL189;
+    }
+    PyObject *cpy_r_r321[3] = {cpy_r_r309, cpy_r_r270, cpy_r_r290};
+    cpy_r_r322 = (PyObject **)&cpy_r_r321;
+    cpy_r_r323 = PyObject_Vectorcall(cpy_r_r280, cpy_r_r322, 3, 0);
+    CPy_DECREF(cpy_r_r280);
+    if (unlikely(cpy_r_r323 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
         goto CPyL191;
     }
-    cpy_r_r358 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__mypyc_attrs__' */
-    cpy_r_r359 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__module__' */
-    cpy_r_r360 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__name__' */
-    cpy_r_r361 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__qualname__' */
-    cpy_r_r362 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__doc__' */
-    cpy_r_r363 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__annotations__' */
-    cpy_r_r364 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__wrapped__' */
-    cpy_r_r365 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__maxsize' */
-    cpy_r_r366 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__typed' */
-    cpy_r_r367 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__ttl' */
-    cpy_r_r368 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__cache' */
-    cpy_r_r369 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__closed' */
-    cpy_r_r370 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__hits' */
-    cpy_r_r371 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__misses' */
-    cpy_r_r372 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_is_coroutine' */
-    cpy_r_r373 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__dict__' */
-    cpy_r_r374 = PyTuple_Pack(15, cpy_r_r359, cpy_r_r360, cpy_r_r361, cpy_r_r362, cpy_r_r363, cpy_r_r364, cpy_r_r365, cpy_r_r366, cpy_r_r367, cpy_r_r368, cpy_r_r369, cpy_r_r370, cpy_r_r371, cpy_r_r372, cpy_r_r373);
-    if (unlikely(cpy_r_r374 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL191;
-    }
-    cpy_r_r375 = PyObject_SetAttr(cpy_r_r356, cpy_r_r358, cpy_r_r374);
-    CPy_DECREF(cpy_r_r374);
-    cpy_r_r376 = cpy_r_r375 >= 0;
-    if (unlikely(!cpy_r_r376)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL191;
-    }
-    CPyType__LRUCacheWrapper = (PyTypeObject *)cpy_r_r356;
-    CPy_INCREF(CPyType__LRUCacheWrapper);
-    cpy_r_r377 = CPyStatic_globals;
-    cpy_r_r378 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_LRUCacheWrapper' */
-    cpy_r_r379 = PyDict_SetItem(cpy_r_r377, cpy_r_r378, cpy_r_r356);
-    CPy_DECREF(cpy_r_r356);
-    cpy_r_r380 = cpy_r_r379 >= 0;
-    if (unlikely(!cpy_r_r380)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
-    }
-    cpy_r_r381 = CPyStatic_globals;
-    cpy_r_r382 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'Generic' */
-    cpy_r_r383 = CPyDict_GetItem(cpy_r_r381, cpy_r_r382);
-    if (unlikely(cpy_r_r383 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
-    }
-    cpy_r_r384 = CPyStatic_globals;
-    cpy_r_r385 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_R' */
-    cpy_r_r386 = CPyDict_GetItem(cpy_r_r384, cpy_r_r385);
-    if (unlikely(cpy_r_r386 == NULL)) {
+    CPy_DECREF(cpy_r_r270);
+    CPy_DECREF(cpy_r_r290);
+    cpy_r_r324 = CPyStatic_globals;
+    cpy_r_r325 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'final' */
+    cpy_r_r326 = CPyDict_GetItem(cpy_r_r324, cpy_r_r325);
+    if (unlikely(cpy_r_r326 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
         goto CPyL192;
     }
-    cpy_r_r387 = CPyStatic_globals;
-    cpy_r_r388 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_T' */
-    cpy_r_r389 = CPyDict_GetItem(cpy_r_r387, cpy_r_r388);
-    if (unlikely(cpy_r_r389 == NULL)) {
+    PyObject *cpy_r_r327[1] = {cpy_r_r323};
+    cpy_r_r328 = (PyObject **)&cpy_r_r327;
+    cpy_r_r329 = PyObject_Vectorcall(cpy_r_r326, cpy_r_r328, 1, 0);
+    CPy_DECREF(cpy_r_r326);
+    if (unlikely(cpy_r_r329 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL192;
+    }
+    CPy_DECREF(cpy_r_r323);
+    CPyType__CacheParameters = (PyTypeObject *)cpy_r_r329;
+    CPy_INCREF(CPyType__CacheParameters);
+    cpy_r_r330 = CPyStatic_globals;
+    cpy_r_r331 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_CacheParameters' */
+    cpy_r_r332 = PyDict_SetItem(cpy_r_r330, cpy_r_r331, cpy_r_r329);
+    CPy_DECREF(cpy_r_r329);
+    cpy_r_r333 = cpy_r_r332 >= 0;
+    if (unlikely(!cpy_r_r333)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL177;
+    }
+    cpy_r_r334 = (PyObject *)CPyType__CacheParameters;
+    cpy_r_r335 = CPyStatic_globals;
+    cpy_r_r336 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'Generic' */
+    cpy_r_r337 = CPyDict_GetItem(cpy_r_r335, cpy_r_r336);
+    if (unlikely(cpy_r_r337 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL177;
+    }
+    cpy_r_r338 = CPyStatic_globals;
+    cpy_r_r339 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_R' */
+    cpy_r_r340 = CPyDict_GetItem(cpy_r_r338, cpy_r_r339);
+    if (unlikely(cpy_r_r340 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
         goto CPyL193;
     }
-    cpy_r_r390.f0 = cpy_r_r386;
-    cpy_r_r390.f1 = cpy_r_r389;
-    cpy_r_r391 = PyTuple_New(2);
-    if (unlikely(cpy_r_r391 == NULL))
-        CPyError_OutOfMemory();
-    PyObject *__tmp67 = cpy_r_r390.f0;
-    PyTuple_SET_ITEM(cpy_r_r391, 0, __tmp67);
-    PyObject *__tmp68 = cpy_r_r390.f1;
-    PyTuple_SET_ITEM(cpy_r_r391, 1, __tmp68);
-    cpy_r_r392 = PyObject_GetItem(cpy_r_r383, cpy_r_r391);
-    CPy_DECREF(cpy_r_r383);
-    CPy_DECREF(cpy_r_r391);
-    if (unlikely(cpy_r_r392 == NULL)) {
+    cpy_r_r341 = PyObject_GetItem(cpy_r_r337, cpy_r_r340);
+    CPy_DECREF(cpy_r_r337);
+    CPy_DECREF(cpy_r_r340);
+    if (unlikely(cpy_r_r341 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
+        goto CPyL177;
     }
-    cpy_r_r393 = PyTuple_Pack(1, cpy_r_r392);
-    CPy_DECREF(cpy_r_r392);
-    if (unlikely(cpy_r_r393 == NULL)) {
+    cpy_r_r342 = PyTuple_Pack(1, cpy_r_r341);
+    CPy_DECREF(cpy_r_r341);
+    if (unlikely(cpy_r_r342 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
+        goto CPyL177;
     }
-    cpy_r_r394 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'faster_async_lru' */
-    cpy_r_r395 = (PyObject *)CPyType__LRUCacheWrapperInstanceMethod_template;
-    cpy_r_r396 = CPyType_FromTemplate(cpy_r_r395, cpy_r_r393, cpy_r_r394);
-    CPy_DECREF(cpy_r_r393);
-    if (unlikely(cpy_r_r396 == NULL)) {
+    cpy_r_r343 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'faster_async_lru' */
+    cpy_r_r344 = (PyObject *)CPyType__CacheItem_template;
+    cpy_r_r345 = CPyType_FromTemplate(cpy_r_r344, cpy_r_r342, cpy_r_r343);
+    CPy_DECREF(cpy_r_r342);
+    if (unlikely(cpy_r_r345 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
+        goto CPyL177;
     }
-    cpy_r_r397 = CPyDef__LRUCacheWrapperInstanceMethod_trait_vtable_setup();
-    if (unlikely(cpy_r_r397 == 2)) {
+    cpy_r_r346 = CPyDef__CacheItem_trait_vtable_setup();
+    if (unlikely(cpy_r_r346 == 2)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", -1, CPyStatic_globals);
         goto CPyL194;
     }
-    cpy_r_r398 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__mypyc_attrs__' */
-    cpy_r_r399 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__module__' */
-    cpy_r_r400 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__name__' */
-    cpy_r_r401 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__qualname__' */
-    cpy_r_r402 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__doc__' */
-    cpy_r_r403 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__annotations__' */
-    cpy_r_r404 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__wrapped__' */
-    cpy_r_r405 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__instance' */
-    cpy_r_r406 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__wrapper' */
-    cpy_r_r407 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_is_coroutine' */
-    cpy_r_r408 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__dict__' */
-    cpy_r_r409 = PyTuple_Pack(10, cpy_r_r399, cpy_r_r400, cpy_r_r401, cpy_r_r402, cpy_r_r403, cpy_r_r404, cpy_r_r405, cpy_r_r406, cpy_r_r407, cpy_r_r408);
+    cpy_r_r347 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__mypyc_attrs__' */
+    cpy_r_r348 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'task' */
+    cpy_r_r349 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'later_call' */
+    cpy_r_r350 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'waiters' */
+    cpy_r_r351 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__dict__' */
+    cpy_r_r352 = PyTuple_Pack(4, cpy_r_r348, cpy_r_r349, cpy_r_r350, cpy_r_r351);
+    if (unlikely(cpy_r_r352 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL194;
+    }
+    cpy_r_r353 = PyObject_SetAttr(cpy_r_r345, cpy_r_r347, cpy_r_r352);
+    CPy_DECREF(cpy_r_r352);
+    cpy_r_r354 = cpy_r_r353 >= 0;
+    if (unlikely(!cpy_r_r354)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL194;
+    }
+    CPyType__CacheItem = (PyTypeObject *)cpy_r_r345;
+    CPy_INCREF(CPyType__CacheItem);
+    cpy_r_r355 = CPyStatic_globals;
+    cpy_r_r356 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_CacheItem' */
+    cpy_r_r357 = PyDict_SetItem(cpy_r_r355, cpy_r_r356, cpy_r_r345);
+    CPy_DECREF(cpy_r_r345);
+    cpy_r_r358 = cpy_r_r357 >= 0;
+    if (unlikely(!cpy_r_r358)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL177;
+    }
+    cpy_r_r359 = CPyStatic_globals;
+    cpy_r_r360 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'Generic' */
+    cpy_r_r361 = CPyDict_GetItem(cpy_r_r359, cpy_r_r360);
+    if (unlikely(cpy_r_r361 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL177;
+    }
+    cpy_r_r362 = CPyStatic_globals;
+    cpy_r_r363 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_R' */
+    cpy_r_r364 = CPyDict_GetItem(cpy_r_r362, cpy_r_r363);
+    if (unlikely(cpy_r_r364 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL195;
+    }
+    cpy_r_r365 = PyObject_GetItem(cpy_r_r361, cpy_r_r364);
+    CPy_DECREF(cpy_r_r361);
+    CPy_DECREF(cpy_r_r364);
+    if (unlikely(cpy_r_r365 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL177;
+    }
+    cpy_r_r366 = PyTuple_Pack(1, cpy_r_r365);
+    CPy_DECREF(cpy_r_r365);
+    if (unlikely(cpy_r_r366 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL177;
+    }
+    cpy_r_r367 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'faster_async_lru' */
+    cpy_r_r368 = (PyObject *)CPyType__LRUCacheWrapper_template;
+    cpy_r_r369 = CPyType_FromTemplate(cpy_r_r368, cpy_r_r366, cpy_r_r367);
+    CPy_DECREF(cpy_r_r366);
+    if (unlikely(cpy_r_r369 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL177;
+    }
+    cpy_r_r370 = CPyDef__LRUCacheWrapper_trait_vtable_setup();
+    if (unlikely(cpy_r_r370 == 2)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", -1, CPyStatic_globals);
+        goto CPyL196;
+    }
+    cpy_r_r371 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__mypyc_attrs__' */
+    cpy_r_r372 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__module__' */
+    cpy_r_r373 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__name__' */
+    cpy_r_r374 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__qualname__' */
+    cpy_r_r375 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__doc__' */
+    cpy_r_r376 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__annotations__' */
+    cpy_r_r377 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__wrapped__' */
+    cpy_r_r378 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__maxsize' */
+    cpy_r_r379 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__typed' */
+    cpy_r_r380 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__ttl' */
+    cpy_r_r381 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__cache' */
+    cpy_r_r382 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__closed' */
+    cpy_r_r383 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__hits' */
+    cpy_r_r384 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__misses' */
+    cpy_r_r385 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_is_coroutine' */
+    cpy_r_r386 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__dict__' */
+    cpy_r_r387 = PyTuple_Pack(15, cpy_r_r372, cpy_r_r373, cpy_r_r374, cpy_r_r375, cpy_r_r376, cpy_r_r377, cpy_r_r378, cpy_r_r379, cpy_r_r380, cpy_r_r381, cpy_r_r382, cpy_r_r383, cpy_r_r384, cpy_r_r385, cpy_r_r386);
+    if (unlikely(cpy_r_r387 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL196;
+    }
+    cpy_r_r388 = PyObject_SetAttr(cpy_r_r369, cpy_r_r371, cpy_r_r387);
+    CPy_DECREF(cpy_r_r387);
+    cpy_r_r389 = cpy_r_r388 >= 0;
+    if (unlikely(!cpy_r_r389)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL196;
+    }
+    CPyType__LRUCacheWrapper = (PyTypeObject *)cpy_r_r369;
+    CPy_INCREF(CPyType__LRUCacheWrapper);
+    cpy_r_r390 = CPyStatic_globals;
+    cpy_r_r391 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_LRUCacheWrapper' */
+    cpy_r_r392 = PyDict_SetItem(cpy_r_r390, cpy_r_r391, cpy_r_r369);
+    CPy_DECREF(cpy_r_r369);
+    cpy_r_r393 = cpy_r_r392 >= 0;
+    if (unlikely(!cpy_r_r393)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL177;
+    }
+    cpy_r_r394 = CPyStatic_globals;
+    cpy_r_r395 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'Generic' */
+    cpy_r_r396 = CPyDict_GetItem(cpy_r_r394, cpy_r_r395);
+    if (unlikely(cpy_r_r396 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL177;
+    }
+    cpy_r_r397 = CPyStatic_globals;
+    cpy_r_r398 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_R' */
+    cpy_r_r399 = CPyDict_GetItem(cpy_r_r397, cpy_r_r398);
+    if (unlikely(cpy_r_r399 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL197;
+    }
+    cpy_r_r400 = CPyStatic_globals;
+    cpy_r_r401 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_T' */
+    cpy_r_r402 = CPyDict_GetItem(cpy_r_r400, cpy_r_r401);
+    if (unlikely(cpy_r_r402 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL198;
+    }
+    cpy_r_r403.f0 = cpy_r_r399;
+    cpy_r_r403.f1 = cpy_r_r402;
+    cpy_r_r404 = PyTuple_New(2);
+    if (unlikely(cpy_r_r404 == NULL))
+        CPyError_OutOfMemory();
+    PyObject *__tmp67 = cpy_r_r403.f0;
+    PyTuple_SET_ITEM(cpy_r_r404, 0, __tmp67);
+    PyObject *__tmp68 = cpy_r_r403.f1;
+    PyTuple_SET_ITEM(cpy_r_r404, 1, __tmp68);
+    cpy_r_r405 = PyObject_GetItem(cpy_r_r396, cpy_r_r404);
+    CPy_DECREF(cpy_r_r396);
+    CPy_DECREF(cpy_r_r404);
+    if (unlikely(cpy_r_r405 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL177;
+    }
+    cpy_r_r406 = PyTuple_Pack(1, cpy_r_r405);
+    CPy_DECREF(cpy_r_r405);
+    if (unlikely(cpy_r_r406 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL177;
+    }
+    cpy_r_r407 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'faster_async_lru' */
+    cpy_r_r408 = (PyObject *)CPyType__LRUCacheWrapperInstanceMethod_template;
+    cpy_r_r409 = CPyType_FromTemplate(cpy_r_r408, cpy_r_r406, cpy_r_r407);
+    CPy_DECREF(cpy_r_r406);
     if (unlikely(cpy_r_r409 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL194;
+        goto CPyL177;
     }
-    cpy_r_r410 = PyObject_SetAttr(cpy_r_r396, cpy_r_r398, cpy_r_r409);
-    CPy_DECREF(cpy_r_r409);
-    cpy_r_r411 = cpy_r_r410 >= 0;
-    if (unlikely(!cpy_r_r411)) {
+    cpy_r_r410 = CPyDef__LRUCacheWrapperInstanceMethod_trait_vtable_setup();
+    if (unlikely(cpy_r_r410 == 2)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", -1, CPyStatic_globals);
+        goto CPyL199;
+    }
+    cpy_r_r411 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__mypyc_attrs__' */
+    cpy_r_r412 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__module__' */
+    cpy_r_r413 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__name__' */
+    cpy_r_r414 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__qualname__' */
+    cpy_r_r415 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__doc__' */
+    cpy_r_r416 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__annotations__' */
+    cpy_r_r417 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__wrapped__' */
+    cpy_r_r418 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__instance' */
+    cpy_r_r419 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__wrapper' */
+    cpy_r_r420 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_is_coroutine' */
+    cpy_r_r421 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__dict__' */
+    cpy_r_r422 = PyTuple_Pack(10, cpy_r_r412, cpy_r_r413, cpy_r_r414, cpy_r_r415, cpy_r_r416, cpy_r_r417, cpy_r_r418, cpy_r_r419, cpy_r_r420, cpy_r_r421);
+    if (unlikely(cpy_r_r422 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL194;
+        goto CPyL199;
     }
-    CPyType__LRUCacheWrapperInstanceMethod = (PyTypeObject *)cpy_r_r396;
+    cpy_r_r423 = PyObject_SetAttr(cpy_r_r409, cpy_r_r411, cpy_r_r422);
+    CPy_DECREF(cpy_r_r422);
+    cpy_r_r424 = cpy_r_r423 >= 0;
+    if (unlikely(!cpy_r_r424)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL199;
+    }
+    CPyType__LRUCacheWrapperInstanceMethod = (PyTypeObject *)cpy_r_r409;
     CPy_INCREF(CPyType__LRUCacheWrapperInstanceMethod);
-    cpy_r_r412 = CPyStatic_globals;
-    cpy_r_r413 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_LRUCacheWrapperInstanceMethod' */
-    cpy_r_r414 = PyDict_SetItem(cpy_r_r412, cpy_r_r413, cpy_r_r396);
-    CPy_DECREF(cpy_r_r396);
-    cpy_r_r415 = cpy_r_r414 >= 0;
-    if (unlikely(!cpy_r_r415)) {
+    cpy_r_r425 = CPyStatic_globals;
+    cpy_r_r426 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_LRUCacheWrapperInstanceMethod' */
+    cpy_r_r427 = PyDict_SetItem(cpy_r_r425, cpy_r_r426, cpy_r_r409);
+    CPy_DECREF(cpy_r_r409);
+    cpy_r_r428 = cpy_r_r427 >= 0;
+    if (unlikely(!cpy_r_r428)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
+        goto CPyL177;
     }
-    cpy_r_r416 = CPyModule_builtins;
-    cpy_r_r417 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'list' */
-    cpy_r_r418 = CPyObject_GetAttr(cpy_r_r416, cpy_r_r417);
-    if (unlikely(cpy_r_r418 == NULL)) {
+    cpy_r_r429 = CPyModule_builtins;
+    cpy_r_r430 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'list' */
+    cpy_r_r431 = CPyObject_GetAttr(cpy_r_r429, cpy_r_r430);
+    if (unlikely(cpy_r_r431 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
+        goto CPyL177;
     }
-    cpy_r_r419 = PyTuple_Pack(1, cpy_r_r418);
-    CPy_DECREF(cpy_r_r418);
-    if (unlikely(cpy_r_r419 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
-    }
-    cpy_r_r420 = (PyObject *)&PyType_Type;
-    cpy_r_r421 = CPy_CalculateMetaclass(cpy_r_r420, cpy_r_r419);
-    if (unlikely(cpy_r_r421 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL195;
-    }
-    cpy_r_r422 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__prepare__' */
-    cpy_r_r423 = PyObject_HasAttr(cpy_r_r421, cpy_r_r422);
-    if (!cpy_r_r423) goto CPyL150;
-    cpy_r_r424 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_HashedSeq' */
-    cpy_r_r425 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__prepare__' */
-    cpy_r_r426 = CPyObject_GetAttr(cpy_r_r421, cpy_r_r425);
-    if (unlikely(cpy_r_r426 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL195;
-    }
-    PyObject *cpy_r_r427[2] = {cpy_r_r424, cpy_r_r419};
-    cpy_r_r428 = (PyObject **)&cpy_r_r427;
-    cpy_r_r429 = PyObject_Vectorcall(cpy_r_r426, cpy_r_r428, 2, 0);
-    CPy_DECREF(cpy_r_r426);
-    if (unlikely(cpy_r_r429 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL195;
-    }
-    if (likely(PyDict_Check(cpy_r_r429)))
-        cpy_r_r430 = cpy_r_r429;
-    else {
-        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "<module>", 408, CPyStatic_globals, "dict", cpy_r_r429);
-        goto CPyL195;
-    }
-    cpy_r_r431 = cpy_r_r430;
-    goto CPyL152;
-CPyL150: ;
-    cpy_r_r432 = PyDict_New();
+    cpy_r_r432 = PyTuple_Pack(1, cpy_r_r431);
+    CPy_DECREF(cpy_r_r431);
     if (unlikely(cpy_r_r432 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL195;
+        goto CPyL177;
     }
-    cpy_r_r431 = cpy_r_r432;
-CPyL152: ;
-    cpy_r_r433 = PyDict_New();
-    if (unlikely(cpy_r_r433 == NULL)) {
+    cpy_r_r433 = (PyObject *)&PyType_Type;
+    cpy_r_r434 = CPy_CalculateMetaclass(cpy_r_r433, cpy_r_r432);
+    if (unlikely(cpy_r_r434 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL196;
+        goto CPyL200;
     }
-    cpy_r_r434 = (PyObject *)&PyUnicode_Type;
-    cpy_r_r435 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__slots__' */
-    cpy_r_r436 = PyDict_SetItem(cpy_r_r433, cpy_r_r435, cpy_r_r434);
-    cpy_r_r437 = cpy_r_r436 >= 0;
-    if (unlikely(!cpy_r_r437)) {
+    cpy_r_r435 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__prepare__' */
+    cpy_r_r436 = PyObject_HasAttr(cpy_r_r434, cpy_r_r435);
+    if (!cpy_r_r436) goto CPyL154;
+    cpy_r_r437 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_HashedSeq' */
+    cpy_r_r438 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__prepare__' */
+    cpy_r_r439 = CPyObject_GetAttr(cpy_r_r434, cpy_r_r438);
+    if (unlikely(cpy_r_r439 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL197;
+        goto CPyL200;
     }
-    cpy_r_r438 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'hashvalue' */
-    cpy_r_r439 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__slots__' */
-    cpy_r_r440 = CPyDict_SetItem(cpy_r_r431, cpy_r_r439, cpy_r_r438);
-    cpy_r_r441 = cpy_r_r440 >= 0;
-    if (unlikely(!cpy_r_r441)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL197;
-    }
-    cpy_r_r442 = CPyDef___init___3__HashedSeq_obj();
+    PyObject *cpy_r_r440[2] = {cpy_r_r437, cpy_r_r432};
+    cpy_r_r441 = (PyObject **)&cpy_r_r440;
+    cpy_r_r442 = PyObject_Vectorcall(cpy_r_r439, cpy_r_r441, 2, 0);
+    CPy_DECREF(cpy_r_r439);
     if (unlikely(cpy_r_r442 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL197;
+        goto CPyL200;
     }
-    cpy_r_r443 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__init__' */
-    cpy_r_r444 = CPyDict_SetItem(cpy_r_r431, cpy_r_r443, cpy_r_r442);
-    CPy_DECREF_NO_IMM(cpy_r_r442);
-    cpy_r_r445 = cpy_r_r444 >= 0;
-    if (unlikely(!cpy_r_r445)) {
+    if (likely(PyDict_Check(cpy_r_r442)))
+        cpy_r_r443 = cpy_r_r442;
+    else {
+        CPy_TypeErrorTraceback("faster_async_lru/__init__.py", "<module>", 411, CPyStatic_globals, "dict", cpy_r_r442);
+        goto CPyL200;
+    }
+    cpy_r_r444 = cpy_r_r443;
+    goto CPyL156;
+CPyL154: ;
+    cpy_r_r445 = PyDict_New();
+    if (unlikely(cpy_r_r445 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL197;
+        goto CPyL200;
     }
-    cpy_r_r446 = CPyDef___hash___3__HashedSeq_obj();
+    cpy_r_r444 = cpy_r_r445;
+CPyL156: ;
+    cpy_r_r446 = PyDict_New();
     if (unlikely(cpy_r_r446 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL197;
+        goto CPyL201;
     }
-    cpy_r_r447 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__hash__' */
-    cpy_r_r448 = CPyDict_SetItem(cpy_r_r431, cpy_r_r447, cpy_r_r446);
-    CPy_DECREF_NO_IMM(cpy_r_r446);
-    cpy_r_r449 = cpy_r_r448 >= 0;
-    if (unlikely(!cpy_r_r449)) {
+    cpy_r_r447 = (PyObject *)&PyUnicode_Type;
+    cpy_r_r448 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__slots__' */
+    cpy_r_r449 = PyDict_SetItem(cpy_r_r446, cpy_r_r448, cpy_r_r447);
+    cpy_r_r450 = cpy_r_r449 >= 0;
+    if (unlikely(!cpy_r_r450)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL197;
+        goto CPyL202;
     }
-    cpy_r_r450 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_HashedSeq' */
-    cpy_r_r451 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__annotations__' */
-    cpy_r_r452 = CPyDict_SetItem(cpy_r_r431, cpy_r_r451, cpy_r_r433);
-    CPy_DECREF(cpy_r_r433);
-    cpy_r_r453 = cpy_r_r452 >= 0;
-    if (unlikely(!cpy_r_r453)) {
+    cpy_r_r451 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'hashvalue' */
+    cpy_r_r452 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__slots__' */
+    cpy_r_r453 = CPyDict_SetItem(cpy_r_r444, cpy_r_r452, cpy_r_r451);
+    cpy_r_r454 = cpy_r_r453 >= 0;
+    if (unlikely(!cpy_r_r454)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL196;
+        goto CPyL202;
     }
-    cpy_r_r454 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'mypyc filler docstring' */
-    cpy_r_r455 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__doc__' */
-    cpy_r_r456 = CPyDict_SetItem(cpy_r_r431, cpy_r_r455, cpy_r_r454);
-    cpy_r_r457 = cpy_r_r456 >= 0;
-    if (unlikely(!cpy_r_r457)) {
+    cpy_r_r455 = CPyDef___init___3__HashedSeq_obj();
+    if (unlikely(cpy_r_r455 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL196;
+        goto CPyL202;
     }
-    cpy_r_r458 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'faster_async_lru' */
-    cpy_r_r459 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__module__' */
-    cpy_r_r460 = CPyDict_SetItem(cpy_r_r431, cpy_r_r459, cpy_r_r458);
-    cpy_r_r461 = cpy_r_r460 >= 0;
-    if (unlikely(!cpy_r_r461)) {
+    cpy_r_r456 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__init__' */
+    cpy_r_r457 = CPyDict_SetItem(cpy_r_r444, cpy_r_r456, cpy_r_r455);
+    CPy_DECREF_NO_IMM(cpy_r_r455);
+    cpy_r_r458 = cpy_r_r457 >= 0;
+    if (unlikely(!cpy_r_r458)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL196;
+        goto CPyL202;
     }
-    PyObject *cpy_r_r462[3] = {cpy_r_r450, cpy_r_r419, cpy_r_r431};
-    cpy_r_r463 = (PyObject **)&cpy_r_r462;
-    cpy_r_r464 = PyObject_Vectorcall(cpy_r_r421, cpy_r_r463, 3, 0);
-    if (unlikely(cpy_r_r464 == NULL)) {
+    cpy_r_r459 = CPyDef___hash___3__HashedSeq_obj();
+    if (unlikely(cpy_r_r459 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL196;
+        goto CPyL202;
     }
-    CPy_DECREF(cpy_r_r419);
-    CPy_DECREF(cpy_r_r431);
-    cpy_r_r465 = CPyStatic_globals;
-    cpy_r_r466 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'mypyc_attr' */
-    cpy_r_r467 = CPyDict_GetItem(cpy_r_r465, cpy_r_r466);
-    if (unlikely(cpy_r_r467 == NULL)) {
+    cpy_r_r460 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__hash__' */
+    cpy_r_r461 = CPyDict_SetItem(cpy_r_r444, cpy_r_r460, cpy_r_r459);
+    CPy_DECREF_NO_IMM(cpy_r_r459);
+    cpy_r_r462 = cpy_r_r461 >= 0;
+    if (unlikely(!cpy_r_r462)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL198;
+        goto CPyL202;
     }
-    cpy_r_r468 = 0 ? Py_True : Py_False;
-    PyObject *cpy_r_r469[1] = {cpy_r_r468};
-    cpy_r_r470 = (PyObject **)&cpy_r_r469;
-    cpy_r_r471 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* ('native_class',) */
-    cpy_r_r472 = PyObject_Vectorcall(cpy_r_r467, cpy_r_r470, 0, cpy_r_r471);
-    CPy_DECREF(cpy_r_r467);
-    if (unlikely(cpy_r_r472 == NULL)) {
+    cpy_r_r463 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_HashedSeq' */
+    cpy_r_r464 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__annotations__' */
+    cpy_r_r465 = CPyDict_SetItem(cpy_r_r444, cpy_r_r464, cpy_r_r446);
+    CPy_DECREF(cpy_r_r446);
+    cpy_r_r466 = cpy_r_r465 >= 0;
+    if (unlikely(!cpy_r_r466)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL198;
+        goto CPyL201;
     }
-    PyObject *cpy_r_r473[1] = {cpy_r_r464};
-    cpy_r_r474 = (PyObject **)&cpy_r_r473;
-    cpy_r_r475 = PyObject_Vectorcall(cpy_r_r472, cpy_r_r474, 1, 0);
-    CPy_DECREF(cpy_r_r472);
-    if (unlikely(cpy_r_r475 == NULL)) {
+    cpy_r_r467 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'mypyc filler docstring' */
+    cpy_r_r468 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__doc__' */
+    cpy_r_r469 = CPyDict_SetItem(cpy_r_r444, cpy_r_r468, cpy_r_r467);
+    cpy_r_r470 = cpy_r_r469 >= 0;
+    if (unlikely(!cpy_r_r470)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL198;
+        goto CPyL201;
     }
-    CPy_DECREF(cpy_r_r464);
-    cpy_r_r476 = CPyStatic_globals;
-    cpy_r_r477 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'final' */
-    cpy_r_r478 = CPyDict_GetItem(cpy_r_r476, cpy_r_r477);
-    if (unlikely(cpy_r_r478 == NULL)) {
+    cpy_r_r471 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'faster_async_lru' */
+    cpy_r_r472 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '__module__' */
+    cpy_r_r473 = CPyDict_SetItem(cpy_r_r444, cpy_r_r472, cpy_r_r471);
+    cpy_r_r474 = cpy_r_r473 >= 0;
+    if (unlikely(!cpy_r_r474)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL199;
+        goto CPyL201;
     }
-    PyObject *cpy_r_r479[1] = {cpy_r_r475};
-    cpy_r_r480 = (PyObject **)&cpy_r_r479;
-    cpy_r_r481 = PyObject_Vectorcall(cpy_r_r478, cpy_r_r480, 1, 0);
-    CPy_DECREF(cpy_r_r478);
-    if (unlikely(cpy_r_r481 == NULL)) {
+    PyObject *cpy_r_r475[3] = {cpy_r_r463, cpy_r_r432, cpy_r_r444};
+    cpy_r_r476 = (PyObject **)&cpy_r_r475;
+    cpy_r_r477 = PyObject_Vectorcall(cpy_r_r434, cpy_r_r476, 3, 0);
+    if (unlikely(cpy_r_r477 == NULL)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL199;
+        goto CPyL201;
     }
-    CPy_DECREF(cpy_r_r475);
-    CPyType__HashedSeq = (PyTypeObject *)cpy_r_r481;
+    CPy_DECREF(cpy_r_r432);
+    CPy_DECREF(cpy_r_r444);
+    cpy_r_r478 = CPyStatic_globals;
+    cpy_r_r479 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'mypyc_attr' */
+    cpy_r_r480 = CPyDict_GetItem(cpy_r_r478, cpy_r_r479);
+    if (unlikely(cpy_r_r480 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL203;
+    }
+    cpy_r_r481 = 0 ? Py_True : Py_False;
+    PyObject *cpy_r_r482[1] = {cpy_r_r481};
+    cpy_r_r483 = (PyObject **)&cpy_r_r482;
+    cpy_r_r484 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* ('native_class',) */
+    cpy_r_r485 = PyObject_Vectorcall(cpy_r_r480, cpy_r_r483, 0, cpy_r_r484);
+    CPy_DECREF(cpy_r_r480);
+    if (unlikely(cpy_r_r485 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL203;
+    }
+    PyObject *cpy_r_r486[1] = {cpy_r_r477};
+    cpy_r_r487 = (PyObject **)&cpy_r_r486;
+    cpy_r_r488 = PyObject_Vectorcall(cpy_r_r485, cpy_r_r487, 1, 0);
+    CPy_DECREF(cpy_r_r485);
+    if (unlikely(cpy_r_r488 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL203;
+    }
+    CPy_DECREF(cpy_r_r477);
+    cpy_r_r489 = CPyStatic_globals;
+    cpy_r_r490 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'final' */
+    cpy_r_r491 = CPyDict_GetItem(cpy_r_r489, cpy_r_r490);
+    if (unlikely(cpy_r_r491 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL204;
+    }
+    PyObject *cpy_r_r492[1] = {cpy_r_r488};
+    cpy_r_r493 = (PyObject **)&cpy_r_r492;
+    cpy_r_r494 = PyObject_Vectorcall(cpy_r_r491, cpy_r_r493, 1, 0);
+    CPy_DECREF(cpy_r_r491);
+    if (unlikely(cpy_r_r494 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL204;
+    }
+    CPy_DECREF(cpy_r_r488);
+    CPyType__HashedSeq = (PyTypeObject *)cpy_r_r494;
     CPy_INCREF(CPyType__HashedSeq);
-    cpy_r_r482 = CPyStatic_globals;
-    cpy_r_r483 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_HashedSeq' */
-    cpy_r_r484 = PyDict_SetItem(cpy_r_r482, cpy_r_r483, cpy_r_r481);
-    CPy_DECREF(cpy_r_r481);
-    cpy_r_r485 = cpy_r_r484 >= 0;
-    if (unlikely(!cpy_r_r485)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
-    }
-    cpy_r_r486 = (PyObject *)CPyType__HashedSeq;
-    cpy_r_r487 = CPyModule_builtins;
-    cpy_r_r488 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'object' */
-    cpy_r_r489 = CPyObject_GetAttr(cpy_r_r487, cpy_r_r488);
-    if (unlikely(cpy_r_r489 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
-    }
-    cpy_r_r490 = PyObject_Vectorcall(cpy_r_r489, 0, 0, 0);
-    CPy_DECREF(cpy_r_r489);
-    if (unlikely(cpy_r_r490 == NULL)) {
-        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
-    }
-    cpy_r_r491.f0 = cpy_r_r490;
-    CPyStatic__KW_MARK = cpy_r_r491;
-    CPy_INCREF(CPyStatic__KW_MARK.f0);
-    cpy_r_r492 = CPyStatic_globals;
-    cpy_r_r493 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_KW_MARK' */
-    cpy_r_r494 = PyTuple_New(1);
-    if (unlikely(cpy_r_r494 == NULL))
-        CPyError_OutOfMemory();
-    PyObject *__tmp69 = cpy_r_r491.f0;
-    PyTuple_SET_ITEM(cpy_r_r494, 0, __tmp69);
-    cpy_r_r495 = CPyDict_SetItem(cpy_r_r492, cpy_r_r493, cpy_r_r494);
+    cpy_r_r495 = CPyStatic_globals;
+    cpy_r_r496 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_HashedSeq' */
+    cpy_r_r497 = PyDict_SetItem(cpy_r_r495, cpy_r_r496, cpy_r_r494);
     CPy_DECREF(cpy_r_r494);
-    cpy_r_r496 = cpy_r_r495 >= 0;
-    if (unlikely(!cpy_r_r496)) {
+    cpy_r_r498 = cpy_r_r497 >= 0;
+    if (unlikely(!cpy_r_r498)) {
         CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
-        goto CPyL173;
+        goto CPyL177;
+    }
+    cpy_r_r499 = (PyObject *)CPyType__HashedSeq;
+    cpy_r_r500 = CPyModule_builtins;
+    cpy_r_r501 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'object' */
+    cpy_r_r502 = CPyObject_GetAttr(cpy_r_r500, cpy_r_r501);
+    if (unlikely(cpy_r_r502 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL177;
+    }
+    cpy_r_r503 = PyObject_Vectorcall(cpy_r_r502, 0, 0, 0);
+    CPy_DECREF(cpy_r_r502);
+    if (unlikely(cpy_r_r503 == NULL)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL177;
+    }
+    cpy_r_r504.f0 = cpy_r_r503;
+    CPyStatic__KW_MARK = cpy_r_r504;
+    CPy_INCREF(CPyStatic__KW_MARK.f0);
+    cpy_r_r505 = CPyStatic_globals;
+    cpy_r_r506 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* '_KW_MARK' */
+    cpy_r_r507 = PyTuple_New(1);
+    if (unlikely(cpy_r_r507 == NULL))
+        CPyError_OutOfMemory();
+    PyObject *__tmp69 = cpy_r_r504.f0;
+    PyTuple_SET_ITEM(cpy_r_r507, 0, __tmp69);
+    cpy_r_r508 = CPyDict_SetItem(cpy_r_r505, cpy_r_r506, cpy_r_r507);
+    CPy_DECREF(cpy_r_r507);
+    cpy_r_r509 = cpy_r_r508 >= 0;
+    if (unlikely(!cpy_r_r509)) {
+        CPy_AddTraceback("faster_async_lru/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_globals);
+        goto CPyL177;
     }
     return 1;
-CPyL173: ;
-    cpy_r_r497 = 2;
-    return cpy_r_r497;
-CPyL174: ;
-    CPy_DecRef(cpy_r_r93);
-    goto CPyL173;
-CPyL175: ;
-    CPy_DecRef(cpy_r_r93);
-    CPy_DecRef(cpy_r_r96);
-    goto CPyL173;
-CPyL176: ;
-    CPy_DecRef(cpy_r_r93);
-    CPy_DecRef(cpy_r_r96);
-    CPy_DecRef(cpy_r_r99);
-    goto CPyL173;
 CPyL177: ;
-    CPy_DecRef(cpy_r_r112);
-    goto CPyL173;
+    cpy_r_r510 = 2;
+    return cpy_r_r510;
 CPyL178: ;
-    CPy_DecRef(cpy_r_r112);
-    CPy_DecRef(cpy_r_r116);
-    goto CPyL173;
+    CPy_DecRef(cpy_r_r71);
+    goto CPyL177;
 CPyL179: ;
-    CPy_DecRef(cpy_r_r130);
-    goto CPyL173;
+    CPy_DecRef(cpy_r_r106);
+    goto CPyL177;
 CPyL180: ;
-    CPy_DecRef(cpy_r_r130);
-    CPy_DecRef(cpy_r_r133);
-    goto CPyL173;
+    CPy_DecRef(cpy_r_r106);
+    CPy_DecRef(cpy_r_r109);
+    goto CPyL177;
 CPyL181: ;
-    CPy_DecRef(cpy_r_r178);
-    goto CPyL173;
+    CPy_DecRef(cpy_r_r106);
+    CPy_DecRef(cpy_r_r109);
+    CPy_DecRef(cpy_r_r112);
+    goto CPyL177;
 CPyL182: ;
-    CPy_DecRef(cpy_r_r257);
-    goto CPyL173;
+    CPy_DecRef(cpy_r_r125);
+    goto CPyL177;
 CPyL183: ;
-    CPy_DecRef(cpy_r_r257);
-    CPy_DecRef(cpy_r_r267);
-    goto CPyL173;
+    CPy_DecRef(cpy_r_r125);
+    CPy_DecRef(cpy_r_r129);
+    goto CPyL177;
 CPyL184: ;
-    CPy_DecRef(cpy_r_r257);
-    CPy_DecRef(cpy_r_r267);
-    CPy_DecRef(cpy_r_r277);
-    goto CPyL173;
+    CPy_DecRef(cpy_r_r143);
+    goto CPyL177;
 CPyL185: ;
-    CPy_DecRef(cpy_r_r257);
-    CPy_DecRef(cpy_r_r267);
-    CPy_DecRef(cpy_r_r277);
-    CPy_DecRef(cpy_r_r279);
-    goto CPyL173;
+    CPy_DecRef(cpy_r_r143);
+    CPy_DecRef(cpy_r_r146);
+    goto CPyL177;
 CPyL186: ;
-    CPy_DecRef(cpy_r_r257);
-    CPy_DecRef(cpy_r_r277);
-    goto CPyL173;
+    CPy_DecRef(cpy_r_r191);
+    goto CPyL177;
 CPyL187: ;
-    CPy_DecRef(cpy_r_r310);
-    goto CPyL173;
+    CPy_DecRef(cpy_r_r270);
+    goto CPyL177;
 CPyL188: ;
-    CPy_DecRef(cpy_r_r324);
-    goto CPyL173;
+    CPy_DecRef(cpy_r_r270);
+    CPy_DecRef(cpy_r_r280);
+    goto CPyL177;
 CPyL189: ;
-    CPy_DecRef(cpy_r_r332);
-    goto CPyL173;
+    CPy_DecRef(cpy_r_r270);
+    CPy_DecRef(cpy_r_r280);
+    CPy_DecRef(cpy_r_r290);
+    goto CPyL177;
 CPyL190: ;
-    CPy_DecRef(cpy_r_r348);
-    goto CPyL173;
+    CPy_DecRef(cpy_r_r270);
+    CPy_DecRef(cpy_r_r280);
+    CPy_DecRef(cpy_r_r290);
+    CPy_DecRef(cpy_r_r292);
+    goto CPyL177;
 CPyL191: ;
-    CPy_DecRef(cpy_r_r356);
-    goto CPyL173;
+    CPy_DecRef(cpy_r_r270);
+    CPy_DecRef(cpy_r_r290);
+    goto CPyL177;
 CPyL192: ;
-    CPy_DecRef(cpy_r_r383);
-    goto CPyL173;
+    CPy_DecRef(cpy_r_r323);
+    goto CPyL177;
 CPyL193: ;
-    CPy_DecRef(cpy_r_r383);
-    CPy_DecRef(cpy_r_r386);
-    goto CPyL173;
+    CPy_DecRef(cpy_r_r337);
+    goto CPyL177;
 CPyL194: ;
-    CPy_DecRef(cpy_r_r396);
-    goto CPyL173;
+    CPy_DecRef(cpy_r_r345);
+    goto CPyL177;
 CPyL195: ;
-    CPy_DecRef(cpy_r_r419);
-    goto CPyL173;
+    CPy_DecRef(cpy_r_r361);
+    goto CPyL177;
 CPyL196: ;
-    CPy_DecRef(cpy_r_r419);
-    CPy_DecRef(cpy_r_r431);
-    goto CPyL173;
+    CPy_DecRef(cpy_r_r369);
+    goto CPyL177;
 CPyL197: ;
-    CPy_DecRef(cpy_r_r419);
-    CPy_DecRef(cpy_r_r431);
-    CPy_DecRef(cpy_r_r433);
-    goto CPyL173;
+    CPy_DecRef(cpy_r_r396);
+    goto CPyL177;
 CPyL198: ;
-    CPy_DecRef(cpy_r_r464);
-    goto CPyL173;
+    CPy_DecRef(cpy_r_r396);
+    CPy_DecRef(cpy_r_r399);
+    goto CPyL177;
 CPyL199: ;
-    CPy_DecRef(cpy_r_r475);
-    goto CPyL173;
+    CPy_DecRef(cpy_r_r409);
+    goto CPyL177;
+CPyL200: ;
+    CPy_DecRef(cpy_r_r432);
+    goto CPyL177;
+CPyL201: ;
+    CPy_DecRef(cpy_r_r432);
+    CPy_DecRef(cpy_r_r444);
+    goto CPyL177;
+CPyL202: ;
+    CPy_DecRef(cpy_r_r432);
+    CPy_DecRef(cpy_r_r444);
+    CPy_DecRef(cpy_r_r446);
+    goto CPyL177;
+CPyL203: ;
+    CPy_DecRef(cpy_r_r477);
+    goto CPyL177;
+CPyL204: ;
+    CPy_DecRef(cpy_r_r488);
+    goto CPyL177;
 }
 
 int CPyGlobalsInit(void)
@@ -14966,15 +14998,16 @@ const char * const CPyLit_Str[] = {
     "\006\005tasks\006closed\vmove_to_end\tcancelled\n_exception\ncall_later",
     "\005\031alru_cache is closed for \fRuntimeError\006result\v__wrapped__\vcreate_task",
     "\005\023_task_done_callback\021add_done_callback\apopitem\004last\020cache_invalidate",
-    "\a\t__wrapper\004func\023iscoroutinefunction\aenviron\024ASYNC_LRU_ALLOW_SYNC\003get\000",
+    "\004\t__wrapper\004func\023iscoroutinefunction\000",
     "\003$Coroutine function is required, got \a{!r:{}}\006format",
     "\003\024_make_unbound_method\bcallable\034 decorating is not supported",
     "\a\023NotImplementedError\thashvalue\003map\bbuiltins\aasyncio\tfunctools\ainspect",
     "\006\002os\003sys\034faster_async_lru/__init__.py\b<module>\nnamedtuple\vcollections",
     "\a\bCallable\tCoroutine\bHashable\017collections.abc\003Any\005Final\aGeneric",
     "\b\bOptional\tTypedDict\aTypeVar\005Union\004cast\005final\boverload\006typing",
-    "\006\nmypyc_attr\017mypy_extensions\fversion_info\004Self\a2.0.5.2\v__version__",
-    "\a\nalru_cache\a__all__\002_T\002_R\005_Coro\003_CB\034functools.partial[_Coro[_R]]",
+    "\006\nmypyc_attr\017mypy_extensions\fversion_info\004Self\a2.0.5.3\v__version__",
+    "\b\nalru_cache\a__all__\aenviron\024ASYNC_LRU_ALLOW_SYNC\003get\nALLOW_SYNC\002_T\002_R",
+    "\003\005_Coro\003_CB\034functools.partial[_Coro[_R]]",
     "\003\"functools.partialmethod[_Coro[_R]]\004_CBP\017_PYTHON_GTE_312",
     "\006\016_PYTHON_LT_314\004hits\006misses\bcurrsize\016CancelledError\apartial",
     "\005\rpartialmethod\006gather\020get_running_loop\006shield\025markcoroutinefunction",
@@ -14996,10 +15029,10 @@ const char * const CPyLit_Int[] = {
 const double CPyLit_Float[] = {0};
 const double CPyLit_Complex[] = {0};
 const int CPyLit_Tuple[] = {
-    14, 4, 19, 20, 21, 22, 1, 35, 3, 54, 54, 54, 3, 55, 55, 55, 3, 56,
-    56, 56, 3, 57, 57, 57, 3, 58, 58, 58, 5, 138, 139, 140, 141, 142, 2,
-    11, 61, 3, 63, 64, 65, 10, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 1,
-    78, 1, 81, 1, 132
+    14, 4, 19, 20, 21, 22, 1, 35, 3, 51, 51, 51, 3, 52, 52, 52, 3, 53,
+    53, 53, 3, 54, 54, 54, 3, 55, 55, 55, 5, 139, 140, 141, 142, 143, 2,
+    11, 58, 3, 60, 61, 62, 10, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 1,
+    75, 1, 78, 1, 133
 };
 const int CPyLit_FrozenSet[] = {0};
 CPyModule *CPyModule_faster_async_lru__internal = NULL;
@@ -15015,6 +15048,7 @@ CPyModule *CPyModule_collections;
 CPyModule *CPyModule_collections___abc;
 CPyModule *CPyModule_typing;
 CPyModule *CPyModule_mypy_extensions;
+PyObject *CPyStatic_ALLOW_SYNC = NULL;
 char CPyStatic__PYTHON_GTE_312 = 2;
 char CPyStatic__PYTHON_LT_314 = 2;
 PyObject *CPyStatic_CancelledError = NULL;

--- a/build/__native_internal.h
+++ b/build/__native_internal.h
@@ -6,7 +6,7 @@
 
 int CPyGlobalsInit(void);
 
-extern PyObject *CPyStatics[150];
+extern PyObject *CPyStatics[151];
 extern const char * const CPyLit_Str[];
 extern const char * const CPyLit_Bytes[];
 extern const char * const CPyLit_Int[];
@@ -27,6 +27,7 @@ extern CPyModule *CPyModule_collections;
 extern CPyModule *CPyModule_collections___abc;
 extern CPyModule *CPyModule_typing;
 extern CPyModule *CPyModule_mypy_extensions;
+extern PyObject *CPyStatic_ALLOW_SYNC;
 extern char CPyStatic__PYTHON_GTE_312;
 extern char CPyStatic__PYTHON_LT_314;
 extern PyObject *CPyStatic_CancelledError;

--- a/faster_async_lru/__init__.py
+++ b/faster_async_lru/__init__.py
@@ -57,6 +57,9 @@ shield: Final = asyncio.shield
 
 markcoroutinefunction: Final = inspect.markcoroutinefunction if _PYTHON_GTE_312 else None  # type: ignore [attr-defined]
 
+#: When set, allows wrapping sync callables by bypassing coroutine checks.
+ALLOW_SYNC: Final = os.environ.get("ASYNC_LRU_ALLOW_SYNC")
+
 
 @final
 class _CacheParameters(TypedDict):
@@ -350,7 +353,7 @@ def _make_wrapper(
         while isinstance(origin, (partial, partialmethod)):
             origin = origin.func
 
-        if not inspect.iscoroutinefunction(origin) and not os.environ.get("ASYNC_LRU_ALLOW_SYNC"):
+        if not inspect.iscoroutinefunction(origin) and not ALLOW_SYNC:
             raise RuntimeError(f"Coroutine function is required, got {fn!r}")
 
         # functools.partialmethod support

--- a/faster_async_lru/__init__.py
+++ b/faster_async_lru/__init__.py
@@ -35,6 +35,9 @@ __version__ = "2.0.5.3"
 __all__ = ("alru_cache",)
 
 
+ALLOW_SYNC: Final = os.environ.get("ASYNC_LRU_ALLOW_SYNC")
+"""When set, allows wrapping sync callables by bypassing coroutine checks."""
+
 _T = TypeVar("_T")
 _R = TypeVar("_R")
 _Coro = Coroutine[Any, Any, _R]
@@ -56,9 +59,6 @@ get_running_loop: Final = asyncio.get_running_loop
 shield: Final = asyncio.shield
 
 markcoroutinefunction: Final = inspect.markcoroutinefunction if _PYTHON_GTE_312 else None  # type: ignore [attr-defined]
-
-#: When set, allows wrapping sync callables by bypassing coroutine checks.
-ALLOW_SYNC: Final = os.environ.get("ASYNC_LRU_ALLOW_SYNC")
 
 
 @final


### PR DESCRIPTION
## Summary
- add a documented `ALLOW_SYNC` module constant in the compile build
- use `ALLOW_SYNC` instead of re-reading `ASYNC_LRU_ALLOW_SYNC` in `_make_wrapper`

## Testing
- not run (compile branch)