### PR TITLE
feat(cicd): limit workflow runners with paths

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -4,15 +4,12 @@ on:
   push:
     paths:
       - '**/*.py'
-      - '**/*.pyi'
       - 'tests/**'
       - 'pyproject.toml'
-      - 'pytest.ini'
       - 'setup.cfg'
       - 'setup.py'
       - 'tox.ini'
       - 'requirements*.txt'
-      - 'poetry.lock'
       - '.github/workflows/codspeed.yml'
     branches:
       - master
@@ -20,15 +17,12 @@ on:
   pull_request:
     paths:
       - '**/*.py'
-      - '**/*.pyi'
       - 'tests/**'
       - 'pyproject.toml'
-      - 'pytest.ini'
       - 'setup.cfg'
       - 'setup.py'
       - 'tox.ini'
       - 'requirements*.txt'
-      - 'poetry.lock'
       - '.github/workflows/codspeed.yml'
     branches:
       - master

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -2,10 +2,34 @@ name: CodSpeed Benchmarks
 
 on:
   push:
+    paths:
+      - '**/*.py'
+      - '**/*.pyi'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - 'pytest.ini'
+      - 'setup.cfg'
+      - 'setup.py'
+      - 'tox.ini'
+      - 'requirements*.txt'
+      - 'poetry.lock'
+      - '.github/workflows/codspeed.yml'
     branches:
       - master
       - '[0-9].[0-9]+'
   pull_request:
+    paths:
+      - '**/*.py'
+      - '**/*.pyi'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - 'pytest.ini'
+      - 'setup.cfg'
+      - 'setup.py'
+      - 'tox.ini'
+      - 'requirements*.txt'
+      - 'poetry.lock'
+      - '.github/workflows/codspeed.yml'
     branches:
       - master
       - '[0-9].[0-9]+'


### PR DESCRIPTION
Summary:
- add paths filters for the mypy/pytest workflow.

Rationale:
- reduce unnecessary runs while keeping safe-first coverage for Python/config changes.

Details:
- update `.github/workflows/codspeed.yml` to include mypy/pytest-relevant paths.