### PR TITLE
feat(cicd): centralize pytest config

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -2,10 +2,28 @@ name: CodSpeed Benchmarks
 
 on:
   push:
+    paths:
+      - '**/*.py'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - 'setup.cfg'
+      - 'setup.py'
+      - 'tox.ini'
+      - 'requirements*.txt'
+      - '.github/workflows/codspeed.yml'
     branches:
       - master
       - '[0-9].[0-9]+'
   pull_request:
+    paths:
+      - '**/*.py'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - 'setup.cfg'
+      - 'setup.py'
+      - 'tox.ini'
+      - 'requirements*.txt'
+      - '.github/workflows/codspeed.yml'
     branches:
       - master
       - '[0-9].[0-9]+'

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -2,28 +2,10 @@ name: CodSpeed Benchmarks
 
 on:
   push:
-    paths:
-      - '**/*.py'
-      - 'tests/**'
-      - 'pyproject.toml'
-      - 'setup.cfg'
-      - 'setup.py'
-      - 'tox.ini'
-      - 'requirements*.txt'
-      - '.github/workflows/codspeed.yml'
     branches:
       - master
       - '[0-9].[0-9]+'
   pull_request:
-    paths:
-      - '**/*.py'
-      - 'tests/**'
-      - 'pyproject.toml'
-      - 'setup.cfg'
-      - 'setup.py'
-      - 'tox.ini'
-      - 'requirements*.txt'
-      - '.github/workflows/codspeed.yml'
     branches:
       - master
       - '[0-9].[0-9]+'
@@ -46,12 +28,11 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements-benchmarks.txt
 
-      - name: Create empty pytest config
-        run: echo "[pytest]" > .empty-pytest.ini
-
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@v4
+        env:
+          PYTEST_ADDOPTS: "-c codspeed-pytest.ini"
         with:
           mode: instrumentation
-          run: pytest -c .empty-pytest.ini --codspeed benchmark.py --timeout=0
+          run: pytest
           token: ${{ secrets.CODSPEED_TOKEN }}

--- a/codspeed-pytest.ini
+++ b/codspeed-pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+addopts = --codspeed --timeout=0
+testpaths =
+    benchmark.py


### PR DESCRIPTION
## Summary
- move pytest CLI args into config files
- keep workflows invoking pytest without inline args

## Manual testing
- [ ] not run (not requested)