### PR TITLE
chore: clarify ruff replacement guidance for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,4 +17,5 @@ All agents must follow these rules:
 11) All mypy configuration (flags, overrides, per-module ignores, and file targets) should go in pyproject.toml. Do not split config across CLI args, mypy.ini, setup.cfg, or workflow steps.
 12) Centralize pytest settings (flags, markers, ignore patterns, and targets) in pyproject.toml, pytest.ini, setup.cfg, or tox.ini; workflows/hooks should call pytest without inline args.
 
+13) Replace them with ruff IF possible while ensuring behavior parity.
 Reference: https://www.conventionalcommits.org/en/v1.0.0/


### PR DESCRIPTION
Summary:
- Document the ruff-first replacement rule and its behavior-parity requirement in AGENTS.md.