### PR TITLE
feat(test): fully test type hints for alru_cache and wrapper classes

### DIFF
--- a/tests/typing/callable_objects.py
+++ b/tests/typing/callable_objects.py
@@ -1,0 +1,48 @@
+"""Mypy-only checks for callable objects and wrapper reuse edge cases."""
+
+from __future__ import annotations
+
+from typing import Generic, TypeVar
+
+from faster_async_lru import _LRUCacheWrapper, alru_cache
+
+from typing_extensions import assert_type
+
+
+class AsyncCallable:
+    async def __call__(self, value: int, /, *, label: str = "") -> str:
+        return f"{value}{label}"
+
+
+async_callable = AsyncCallable()
+wrapped_callable = alru_cache(async_callable)
+
+assert_type(wrapped_callable, _LRUCacheWrapper[str])
+
+
+T = TypeVar("T")
+
+
+class Box(Generic[T]):
+    async def __call__(self, value: T) -> T:
+        return value
+
+
+boxed_int = Box[int]()
+wrapped_boxed_int = alru_cache(boxed_int)
+
+assert_type(wrapped_boxed_int, _LRUCacheWrapper[int])
+
+wrapped_twice = alru_cache(wrapped_boxed_int)
+assert_type(wrapped_twice, _LRUCacheWrapper[int])
+
+
+async def _check_call_results() -> None:
+    callable_result = await wrapped_callable(1, label="x")
+    assert_type(callable_result, str)
+
+    boxed_result = await wrapped_boxed_int(3)
+    assert_type(boxed_result, int)
+
+    wrapped_twice_result = await wrapped_twice(4)
+    assert_type(wrapped_twice_result, int)

--- a/tests/typing/decorator_cases.py
+++ b/tests/typing/decorator_cases.py
@@ -1,0 +1,219 @@
+"""Mypy-only checks for alru_cache decorator overloads and call signatures."""
+
+from __future__ import annotations
+
+from typing import NewType, Optional, Union
+
+from faster_async_lru import _LRUCacheWrapper, alru_cache
+
+from typing_extensions import Annotated, Literal, assert_type
+
+
+class Widget:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+UserId = NewType("UserId", int)
+
+
+@alru_cache
+async def direct_int(value: int, /, label: str = "") -> int:
+    return value
+
+
+@alru_cache
+async def direct_str(value: str) -> str:
+    return value
+
+
+@alru_cache
+async def direct_none(flag: bool) -> None:
+    if flag:
+        return None
+    return None
+
+
+@alru_cache
+async def direct_union(value: Union[int, str]) -> Union[int, str]:
+    return value
+
+
+@alru_cache
+async def direct_optional_union(
+    value: Optional[Union[int, str]],
+) -> Optional[Union[int, str]]:
+    return value
+
+
+@alru_cache
+async def direct_optional(value: Optional[Widget]) -> Optional[Widget]:
+    return value
+
+
+@alru_cache
+async def direct_custom(value: str) -> Widget:
+    return Widget(value)
+
+
+@alru_cache
+async def direct_list(value: str) -> list[Widget]:
+    return [Widget(value)]
+
+
+@alru_cache
+async def direct_literal(flag: bool) -> Literal["ok"]:
+    if flag:
+        return "ok"
+    return "ok"
+
+
+@alru_cache
+async def direct_newtype(value: UserId) -> UserId:
+    return value
+
+
+@alru_cache
+async def direct_tuple(value: int, label: str) -> tuple[int, str]:
+    return value, label
+
+
+@alru_cache
+async def direct_dict(value: str) -> dict[str, Widget]:
+    return {value: Widget(value)}
+
+
+@alru_cache
+async def direct_annotated(value: Annotated[int, "id"]) -> Annotated[int, "id"]:
+    return value
+
+
+@alru_cache(maxsize=0, typed=True, ttl=0.1)
+async def factory_positional_only(value: int, /, suffix: str) -> str:
+    return f"{value}{suffix}"
+
+
+@alru_cache(maxsize=1, typed=False, ttl=None)
+async def factory_keyword_only(*, value: int, suffix: str = "") -> str:
+    return f"{value}{suffix}"
+
+
+@alru_cache(maxsize=128, typed=False, ttl=None)
+async def factory_defaulted(value: int, label: str = "x") -> int:
+    return value
+
+
+@alru_cache(maxsize=64, typed=True, ttl=None)
+async def factory_mixed(value: int, /, *extra: int, label: str) -> int:
+    return value + len(extra) + len(label)
+
+
+@alru_cache(maxsize=None, typed=True)
+async def factory_var_args(*values: int, **labels: str) -> int:
+    return len(values) + len(labels)
+
+
+@alru_cache()
+async def factory_defaults(value: int, label: str = "default") -> str:
+    return f"{value}{label}"
+
+
+@alru_cache(maxsize=None, typed=False, ttl=0.0)
+async def factory_ttl_zero(value: int) -> int:
+    return value
+
+
+wrapped_from_callable = alru_cache(direct_int)
+wrapped_no_args = alru_cache()(direct_str)
+assert_type(wrapped_from_callable, _LRUCacheWrapper[int])
+assert_type(wrapped_no_args, _LRUCacheWrapper[str])
+assert_type(direct_int, _LRUCacheWrapper[int])
+assert_type(direct_none, _LRUCacheWrapper[None])
+cache_invalidate_result = direct_int.cache_invalidate(1, label="x")
+assert_type(cache_invalidate_result, bool)
+
+
+async def plain_callable(value: float) -> float:
+    return value
+
+
+wrapped_plain = alru_cache(plain_callable)
+assert_type(wrapped_plain, _LRUCacheWrapper[float])
+double_wrapped = alru_cache(wrapped_plain)
+assert_type(double_wrapped, _LRUCacheWrapper[float])
+
+
+async def _check_call_results() -> None:
+    direct_int_value = await direct_int(1)
+    assert_type(direct_int_value, int)
+
+    wrapped_result = await wrapped_from_callable(1)
+    assert_type(wrapped_result, int)
+
+    direct_int_result = await direct_int(1, "a")
+    assert_type(direct_int_result, int)
+
+    direct_str_result = await direct_str("value")
+    assert_type(direct_str_result, str)
+
+    await direct_none(True)
+
+    direct_union_int_result = await direct_union(1)
+    assert_type(direct_union_int_result, Union[int, str])
+
+    direct_union_str_result = await direct_union("x")
+    assert_type(direct_union_str_result, Union[int, str])
+
+    direct_optional_union_result = await direct_optional_union(None)
+    assert_type(direct_optional_union_result, Optional[Union[int, str]])
+
+    direct_optional_result = await direct_optional(None)
+    assert_type(direct_optional_result, Optional[Widget])
+
+    direct_custom_result = await direct_custom("name")
+    assert_type(direct_custom_result, Widget)
+
+    direct_list_result = await direct_list("name")
+    assert_type(direct_list_result, list[Widget])
+
+    direct_literal_result = await direct_literal(True)
+    assert_type(direct_literal_result, Literal["ok"])
+
+    direct_newtype_result = await direct_newtype(UserId(5))
+    assert_type(direct_newtype_result, UserId)
+
+    direct_tuple_result = await direct_tuple(1, "a")
+    assert_type(direct_tuple_result, tuple[int, str])
+
+    direct_dict_result = await direct_dict("key")
+    assert_type(direct_dict_result, dict[str, Widget])
+
+    direct_annotated_result = await direct_annotated(3)
+    assert_type(direct_annotated_result, Annotated[int, "id"])
+
+    factory_positional_result = await factory_positional_only(3, "s")
+    assert_type(factory_positional_result, str)
+
+    factory_keyword_result = await factory_keyword_only(value=3)
+    assert_type(factory_keyword_result, str)
+
+    factory_defaulted_result = await factory_defaulted(3)
+    assert_type(factory_defaulted_result, int)
+
+    factory_mixed_result = await factory_mixed(3, 4, 5, label="zz")
+    assert_type(factory_mixed_result, int)
+
+    factory_varargs_result = await factory_var_args(1, 2, 3, label="x")
+    assert_type(factory_varargs_result, int)
+
+    factory_defaults_result = await factory_defaults(2)
+    assert_type(factory_defaults_result, str)
+
+    factory_ttl_result = await factory_ttl_zero(5)
+    assert_type(factory_ttl_result, int)
+
+    wrapped_no_args_result = await wrapped_no_args("value")
+    assert_type(wrapped_no_args_result, str)
+
+    wrapped_plain_result = await wrapped_plain(2.5)
+    assert_type(wrapped_plain_result, float)

--- a/tests/typing/descriptor_edge_cases.py
+++ b/tests/typing/descriptor_edge_cases.py
@@ -1,0 +1,79 @@
+"""Mypy-only checks for descriptor access and explicit __get__ usage."""
+
+from __future__ import annotations
+
+from typing import Optional, Union
+
+from faster_async_lru import _LRUCacheWrapper, _LRUCacheWrapperInstanceMethod, alru_cache
+
+from typing_extensions import assert_type
+
+
+async def free_function(value: int) -> int:
+    return value
+
+
+cached_free = alru_cache(free_function)
+
+
+class Host:
+    cached = cached_free
+
+    def __init__(self, bias: int) -> None:
+        self.bias = bias
+
+    @alru_cache
+    async def method(self, value: int) -> int:
+        return value + self.bias
+
+
+host = Host(2)
+
+assert_type(
+    Host.cached,
+    Union[
+        _LRUCacheWrapper[int],
+        _LRUCacheWrapperInstanceMethod[int, Optional[Host]],
+    ],
+)
+assert_type(
+    host.cached,
+    Union[_LRUCacheWrapper[int], _LRUCacheWrapperInstanceMethod[int, Host]],
+)
+
+wrapper_from_get = cached_free.__get__(None, Host)
+assert_type(
+    wrapper_from_get,
+    Union[
+        _LRUCacheWrapper[int],
+        _LRUCacheWrapperInstanceMethod[int, Optional[Host]],
+    ],
+)
+bound_from_get = cached_free.__get__(host, Host)
+assert_type(
+    bound_from_get,
+    Union[_LRUCacheWrapper[int], _LRUCacheWrapperInstanceMethod[int, Host]],
+)
+
+assert_type(
+    Host.method,
+    Union[
+        _LRUCacheWrapper[int],
+        _LRUCacheWrapperInstanceMethod[int, Optional[Host]],
+    ],
+)
+assert_type(
+    host.method,
+    Union[_LRUCacheWrapper[int], _LRUCacheWrapperInstanceMethod[int, Host]],
+)
+
+
+async def _check_call_results() -> None:
+    host_cached_result = await host.cached(3)
+    assert_type(host_cached_result, int)
+
+    bound_get_result = await bound_from_get(4)
+    assert_type(bound_get_result, int)
+
+    host_method_result = await host.method(5)
+    assert_type(host_method_result, int)

--- a/tests/typing/negative_cases.py
+++ b/tests/typing/negative_cases.py
@@ -1,0 +1,32 @@
+"""Mypy-only negative checks for invalid alru_cache usage."""
+
+from __future__ import annotations
+
+from faster_async_lru import alru_cache
+
+
+def sync_func(value: int) -> int:
+    return value
+
+
+alru_cache(sync_func)  # type: ignore[arg-type]
+
+alru_cache("not a callable")  # type: ignore[call-overload]
+
+alru_cache(3.14)  # type: ignore[call-overload]
+
+alru_cache(maxsize="invalid")  # type: ignore[call-overload]
+
+alru_cache(maxsize=1.5)  # type: ignore[call-overload]
+
+alru_cache(ttl="invalid")  # type: ignore[call-overload]
+
+alru_cache(typed="invalid")  # type: ignore[call-overload]
+
+
+@alru_cache
+async def accepts_hashable(value: int) -> int:
+    return value
+
+
+accepts_hashable.cache_invalidate(["unhashable"])  # type: ignore[arg-type]

--- a/tests/typing/partials.py
+++ b/tests/typing/partials.py
@@ -1,0 +1,62 @@
+"""Mypy-only checks for functools.partial and partialmethod support."""
+
+from __future__ import annotations
+
+from functools import partial, partialmethod
+from typing import Optional, Union
+
+from faster_async_lru import _LRUCacheWrapper, _LRUCacheWrapperInstanceMethod, alru_cache
+
+from typing_extensions import assert_type
+
+
+async def base(value: int, suffix: str) -> str:
+    return f"{value}{suffix}"
+
+
+partial_func = partial(base, 1)
+partial_wrapped = alru_cache(partial_func)
+
+assert_type(partial_wrapped, _LRUCacheWrapper[str])
+
+
+class Handler:
+    async def build(self, value: int, suffix: str) -> str:
+        return f"{value}{suffix}"
+
+    cached_build = alru_cache(partialmethod(build, 2))
+
+    async def build_kw(self, value: int, *, suffix: str) -> str:
+        return f"{value}{suffix}"
+
+    cached_build_kw = alru_cache(partialmethod(build_kw, 3, suffix="z"))
+
+
+handler = Handler()
+
+assert_type(
+    Handler.cached_build,
+    Union[
+        _LRUCacheWrapper[str],
+        _LRUCacheWrapperInstanceMethod[str, Optional[Handler]],
+    ],
+)
+assert_type(
+    handler.cached_build,
+    Union[_LRUCacheWrapper[str], _LRUCacheWrapperInstanceMethod[str, Handler]],
+)
+assert_type(
+    handler.cached_build_kw,
+    Union[_LRUCacheWrapper[str], _LRUCacheWrapperInstanceMethod[str, Handler]],
+)
+
+
+async def _check_call_results() -> None:
+    partial_result = await partial_wrapped("x")
+    assert_type(partial_result, str)
+
+    handler_result = await handler.cached_build("y")
+    assert_type(handler_result, str)
+
+    handler_kw_result = await handler.cached_build_kw()
+    assert_type(handler_kw_result, str)

--- a/tests/typing/signature_matrix.py
+++ b/tests/typing/signature_matrix.py
@@ -1,0 +1,72 @@
+"""Mypy-only checks for parameter shape permutations."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from faster_async_lru import _LRUCacheWrapper, alru_cache
+
+from typing_extensions import assert_type
+
+
+@alru_cache
+async def positional_only(x: int, /, y: int) -> int:
+    return x + y
+
+
+@alru_cache
+async def keyword_only(*, x: int, y: int = 0) -> int:
+    return x + y
+
+
+@alru_cache
+async def var_args(*values: int) -> int:
+    return sum(values)
+
+
+@alru_cache
+async def var_kwargs(**values: int) -> int:
+    return sum(values.values())
+
+
+@alru_cache
+async def mixed_args(x: int, /, y: int, *values: int, scale: int = 1) -> int:
+    return (x + y + sum(values)) * scale
+
+
+@alru_cache
+async def optional_args(x: Optional[int] = None) -> Optional[int]:
+    return x
+
+
+@alru_cache
+async def kw_only_optional(*, x: Optional[int], y: Optional[str] = None) -> int:
+    return 0 if x is None else x
+
+
+@alru_cache(maxsize=16, typed=True, ttl=None)
+async def typed_factory(x: int, /, y: str, *, z: float = 0.0) -> str:
+    return f"{x}{y}{z}"
+
+
+assert_type(positional_only, _LRUCacheWrapper[int])
+assert_type(keyword_only, _LRUCacheWrapper[int])
+assert_type(var_args, _LRUCacheWrapper[int])
+assert_type(var_kwargs, _LRUCacheWrapper[int])
+assert_type(mixed_args, _LRUCacheWrapper[int])
+assert_type(optional_args, _LRUCacheWrapper[Optional[int]])
+assert_type(kw_only_optional, _LRUCacheWrapper[int])
+assert_type(typed_factory, _LRUCacheWrapper[str])
+
+
+async def _check_call_results() -> None:
+    assert_type(await positional_only(1, 2), int)
+    assert_type(await keyword_only(x=1, y=2), int)
+    assert_type(await var_args(1, 2, 3), int)
+    assert_type(await var_kwargs(a=1, b=2), int)
+    assert_type(await mixed_args(1, 2, 3, 4, scale=2), int)
+    assert_type(await optional_args(None), Optional[int])
+    assert_type(await optional_args(5), Optional[int])
+    assert_type(await kw_only_optional(x=None), int)
+    assert_type(await kw_only_optional(x=1, y="a"), int)
+    assert_type(await typed_factory(1, "x", z=1.5), str)

--- a/tests/typing/wrapper_methods.py
+++ b/tests/typing/wrapper_methods.py
@@ -1,0 +1,83 @@
+"""Mypy-only checks for wrapper methods and descriptor behavior."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Optional, Union
+
+from faster_async_lru import (
+    _CacheInfo,
+    _CacheParameters,
+    _LRUCacheWrapper,
+    _LRUCacheWrapperInstanceMethod,
+    alru_cache,
+)
+
+from typing_extensions import assert_type
+
+
+@alru_cache
+async def fetch(value: int, *, label: str = "") -> str:
+    return f"{value}{label}"
+
+
+assert_type(fetch, _LRUCacheWrapper[str])
+fetch_cache_clear: Callable[[], None] = fetch.cache_clear
+fetch_cache_close: Callable[..., Awaitable[None]] = fetch.cache_close
+
+fetch_invalidate = fetch.cache_invalidate(1, label="x")
+assert_type(fetch_invalidate, bool)
+fetch_info = fetch.cache_info()
+assert_type(fetch_info, _CacheInfo)
+fetch_parameters = fetch.cache_parameters()
+assert_type(fetch_parameters, _CacheParameters)
+assert_type(fetch_parameters["typed"], bool)
+assert_type(fetch_parameters["maxsize"], Optional[int])
+assert_type(fetch_parameters["tasks"], int)
+assert_type(fetch_parameters["closed"], bool)
+
+
+class Service:
+    @alru_cache
+    async def compute(self, value: int, *, scale: float = 1.0) -> float:
+        return value * scale
+
+
+service = Service()
+
+assert_type(
+    Service.compute,
+    Union[
+        _LRUCacheWrapper[float],
+        _LRUCacheWrapperInstanceMethod[float, Optional[Service]],
+    ],
+)
+assert_type(
+    service.compute,
+    Union[_LRUCacheWrapper[float], _LRUCacheWrapperInstanceMethod[float, Service]],
+)
+service_cache_clear: Callable[[], None] = service.compute.cache_clear
+service_cache_close: Callable[..., Awaitable[None]] = service.compute.cache_close
+
+service_invalidate = service.compute.cache_invalidate(3, scale=2.0)
+assert_type(service_invalidate, bool)
+service_info = service.compute.cache_info()
+assert_type(service_info, _CacheInfo)
+service_parameters = service.compute.cache_parameters()
+assert_type(service_parameters, _CacheParameters)
+assert_type(service_parameters["typed"], bool)
+assert_type(service_parameters["maxsize"], Optional[int])
+assert_type(service_parameters["tasks"], int)
+assert_type(service_parameters["closed"], bool)
+
+
+async def _check_call_results() -> None:
+    fetch_result = await fetch(1, label="x")
+    assert_type(fetch_result, str)
+
+    await fetch.cache_close()
+
+    service_result = await service.compute(3, scale=2.0)
+    assert_type(service_result, float)
+
+    await service.compute.cache_close()


### PR DESCRIPTION
### Summary
- Add a broad set of mypy-only typing checks under `tests/typing/` to exercise `alru_cache` decorator overloads, wrapper/descriptor behavior, partial/partialmethod support, callable objects, and negative typing cases.
- Introduce new modules `callable_objects.py` and `descriptor_edge_cases.py` and extend existing typing files with literal/newtype/annotated return shapes, factory-no-arg usage, and invalid-usage assertions.
- Keep these files non-runtime (non `test_*.py`) so they are picked up by the repository's strict mypy configuration without pytest collection.

### Rationale
- Decorators and descriptor wrappers are a common source of downstream typing regressions, so increasing static coverage improves confidence for consumers that rely on accurate inference.
- The project ships `py.typed` and runs mypy in strict mode over package and tests, so these mypy-only modules provide deterministic type-surface checks without introducing runtime test flakiness.
- The changes intentionally avoid touching existing runtime code or preexisting mypy/pytest failures so the diff is focused on expanding type coverage only.

### Details
- Files added: `tests/typing/callable_objects.py`, `tests/typing/descriptor_edge_cases.py`; Files extended: `tests/typing/decorator_cases.py`, `tests/typing/partials.py`, `tests/typing/wrapper_methods.py`, `tests/typing/negative_cases.py`, `tests/typing/signature_matrix.py`.
- The modules assert wrapper types with `typing_extensions.assert_type`, exercise `alru_cache` in decorator/factory/direct-call modes, cover bound/unbound descriptor access, and include explicit mypy-expected failures for invalid inputs.
- Automated checks run: `python -m pytest` (48 collected, 47 passed, 1 failed due to the environment loading the package from `faster_async_lru/__init__.py` rather than the compiled extension), and `python -m mypy` (did not finish cleanly due to pre-existing `unused-ignore` and `comparison-overlap` errors in the package/tests); `flake8` also reports pre-existing import-order/whitespace warnings in upstream files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69765f799dfc83318a4390eb7092fc67)