### PR TITLE
docs: add worktree build/ cleanup note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,5 +17,6 @@ All agents must follow these rules:
 11) All mypy configuration (flags, overrides, per-module ignores, and file targets) should go in pyproject.toml. Do not split config across CLI args, mypy.ini, setup.cfg, or workflow steps.
 12) Centralize pytest settings (flags, markers, ignore patterns, and targets) in pyproject.toml, pytest.ini, setup.cfg, or tox.ini; workflows/hooks should call pytest without inline args.
 13) For unittest workflows, prefer python -m unittest without inline args; if discovery arguments are required, centralize them in a single script and call that from CI.
+14) Local `pip install .` generates `build/`; remove it before closing a worktree to avoid a dirty state.
 
 Reference: https://www.conventionalcommits.org/en/v1.0.0/


### PR DESCRIPTION
Summary:
- Add an AGENTS rule reminding contributors to remove `build/` after local `pip install .` so worktrees stay clean.

Rationale:
- Local installs generate build artifacts that otherwise leave worktrees dirty; documenting the cleanup expectation prevents churn.

Details:
- Updated `AGENTS.md` with the new cleanup rule.
- Tests: `python -m pytest` (fails: `tests/test_compiled_extension.py::test_compiled_extension_loaded` expects a compiled extension but origin resolved to `faster_async_lru/__init__.py` even after `python setup.py build_ext --inplace`).