### PR TITLE
test: add hint for compiled extension import failure

### DIFF
--- a/tests/test_compiled_extension.py
+++ b/tests/test_compiled_extension.py
@@ -8,5 +8,7 @@ def test_compiled_extension_loaded() -> None:
     assert origin is not None
     assert origin.endswith(tuple(importlib.machinery.EXTENSION_SUFFIXES)), (
         "Expected faster_async_lru to be loaded from a compiled extension module, "
-        f"got {origin!r}."
+        f"got {origin!r}. "
+        "Hint: if the `faster_async_lru/` package dir exists, importlib prefers it "
+        "over the top-level extension; build in-place or clean it."
     )


### PR DESCRIPTION
Summary:
- Add a one-line hint to the compiled-extension assertion to explain why `__init__.py` is selected and how to resolve it.

Rationale:
- When the package directory exists, importlib prefers it over the top-level `.so`; the current error message doesn’t point devs to that root cause.

Details:
- Updated `tests/test_compiled_extension.py` assertion message with a concise import-order hint.
- Tests: `python -m pytest` (fails: `tests/test_compiled_extension.py::test_compiled_extension_loaded` — origin resolves to `faster_async_lru/__init__.py`).