### PR TITLE
chore(deps): update dependency pytest-codspeed to v4.3.0

### DIFF
--- a/requirements-benchmarks.txt
+++ b/requirements-benchmarks.txt
@@ -2,4 +2,4 @@
 -r requirements-test.txt
 
 async-lru==2.0.5
-pytest-codspeed==4.2.0
+pytest-codspeed==4.3.0


### PR DESCRIPTION
## Summary
- Bump pytest-codspeed in requirements-benchmarks.txt from 4.2.0 to 4.3.0 on compile.

## Rationale
- Keep compile benchmark deps aligned with master PR #80.

## Details
- requirements-benchmarks.txt: 4.2.0 → 4.3.0 (async-lru line unchanged).
- Tests: python -m pytest (fails at test_compiled_extension_loaded: module loaded from faster_async_lru/__init__.py).
- Tests: python setup.py build_ext --inplace, then python -m pytest with faster_async_lru/ temporarily moved to force .so import (15 failures in internal/cache tests).
