### PR TITLE
docs(agents): clarify pytest test guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,5 +16,6 @@ All agents must follow these rules:
 10) Use one of `paths` or `paths-ignore` in every workflow file to make sure workflows only run when required.
 11) All mypy configuration (flags, overrides, per-module ignores, and file targets) should go in pyproject.toml. Do not split config across CLI args, mypy.ini, setup.cfg, or workflow steps.
 12) Centralize pytest settings (flags, markers, ignore patterns, and targets) in pyproject.toml, pytest.ini, setup.cfg, or tox.ini; workflows/hooks should call pytest without inline args.
+13) This repo uses pytest. Run tests with python -m pytest (or make test) and keep pytest settings centralized in setup.cfg/pyproject/tox.ini.
 
 Reference: https://www.conventionalcommits.org/en/v1.0.0/


### PR DESCRIPTION
## Summary
- Add pytest-specific guidance for test execution in AGENTS rule #13.

## Rationale
- This repo’s test suite is pytest-based; the guidance should match how tests are actually run here.

## Details
- AGENTS.md: add #13 with pytest-specific wording.
- Tests: `python -m pytest` (failed: DeprecationWarning: `'asyncio.iscoroutinefunction' is deprecated` leading to multiple failures).
