### PR TITLE
docs(agents): clarify pytest test guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ All agents must follow these rules:
 10) Use one of `paths` or `paths-ignore` in every workflow file to make sure workflows only run when required.
 11) All mypy configuration (flags, overrides, per-module ignores, and file targets) should go in pyproject.toml. Do not split config across CLI args, mypy.ini, setup.cfg, or workflow steps.
 12) Centralize pytest settings (flags, markers, ignore patterns, and targets) in pyproject.toml, pytest.ini, setup.cfg, or tox.ini; workflows/hooks should call pytest without inline args.
-13) For unittest workflows, prefer python -m unittest without inline args; if discovery arguments are required, centralize them in a single script and call that from CI.
+13) This repo uses pytest. Run tests with python -m pytest (or make test) and keep pytest settings centralized in setup.cfg/pyproject/tox.ini.
 14) Local `pip install .` generates `build/`; remove it before closing a worktree to avoid a dirty state.
 
 Reference: https://www.conventionalcommits.org/en/v1.0.0/


### PR DESCRIPTION
## Summary
- Update AGENTS rule #13 to reflect pytest usage in this repo.

## Rationale
- The previous unittest guidance didn’t match the compile branch test workflow.

## Details
- AGENTS.md: replace #13 wording with pytest-specific guidance.
- Tests: `python -m pytest` (failed: `test_compiled_extension_loaded` expected .so, got `faster_async_lru/__init__.py`).
