### PR TITLE
chore: enable Renovate updates for compile branch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,9 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "baseBranches": [
+    "master",
+    "compile"
   ]
 }


### PR DESCRIPTION
**Summary**
- Enable Renovate PRs against `compile` alongside `master`.

**Rationale**
- Keeps the compile branch’s dependencies updated without changing master’s behavior.

**Details**
- Add `baseBranches: ["master", "compile"]` to `renovate.json`.
- Tests: `python -m pytest` (fails on Python 3.14 due to DeprecationWarning from `asyncio.iscoroutinefunction`).