### PR TITLE
fix(benchmarks): force cache-miss evictions for accurate baselines

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -136,8 +136,9 @@ def test_cache_miss_benchmark(
     run_loop: Callable[..., Any],
     func: _LRUCacheWrapper[Any],
 ) -> None:
-    unique_objects = [object() for _ in range(128)]
     func.cache_clear()
+    # Use 2048 objects (16x maxsize=128) to force evictions and measure actual misses.
+    unique_objects = [object() for _ in range(2048)]
 
     async def run() -> None:
         for obj in unique_objects:


### PR DESCRIPTION
## Summary
- Increase the cache-miss benchmark workload to 2048 objects to force evictions and measure true misses.

## Rationale
- We are migrating recent changes from the upstream repo and want this benchmark adjustment isolated so it does not pollute the review process for the other PR.

## Details
- Update `test_cache_miss_benchmark` to use 2048 objects (16x maxsize=128) after clearing the cache.
