### PR TITLE
chore: sync upstream master (resolve benchmark conflict)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -166,11 +166,7 @@ jobs:
         fix_issue_repl: "(#\\1)"
 
     - name: >-
-        Publish d
-d83d
-dc0d
-d83d
-dce6 to PyPI
+        Publish 🐍📦 to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
 
     - name: Sign the dists with Sigstore

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -166,7 +166,7 @@ jobs:
         fix_issue_repl: "(#\\1)"
 
     - name: >-
-        Publish 0d
+        Publish d
 d83d
 dc0d
 d83d

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -6,10 +6,34 @@ on:
       - master
       - '[0-9].[0-9]+'  # matches to backport branches, e.g. 3.6
     tags: [ 'v*' ]
+    paths:
+      - '**/*.py'
+      - 'tests/**'
+      - 'CHANGES.rst'
+      - 'MANIFEST.in'
+      - 'README.rst'
+      - 'pyproject.toml'
+      - 'setup.cfg'
+      - 'setup.py'
+      - 'tox.ini'
+      - 'requirements*.txt'
+      - '.github/workflows/ci-cd.yml'
   pull_request:
     branches:
       - master
       - '[0-9].[0-9]+'
+    paths:
+      - '**/*.py'
+      - 'tests/**'
+      - 'CHANGES.rst'
+      - 'MANIFEST.in'
+      - 'README.rst'
+      - 'pyproject.toml'
+      - 'setup.cfg'
+      - 'setup.py'
+      - 'tox.ini'
+      - 'requirements*.txt'
+      - '.github/workflows/ci-cd.yml'
 
 
 jobs:
@@ -142,7 +166,11 @@ jobs:
         fix_issue_repl: "(#\\1)"
 
     - name: >-
-        Publish 🐍📦 to PyPI
+        Publish 0d
+d83d
+dc0d
+d83d
+dce6 to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
 
     - name: Sign the dists with Sigstore

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,13 @@ CHANGES
 
 .. towncrier release notes start
 
+
+2.1.0 (2026-01-17)
+==================
+
+- Fixed cancelling of task when all tasks waiting on it have been cancelled.
+- Fixed DeprecationWarning from asyncio.iscoroutinefunction.
+
 2.0.5 (2025-03-16)
 ==================
 

--- a/README.rst
+++ b/README.rst
@@ -16,11 +16,11 @@ async-lru
 
 .. image:: https://img.shields.io/matrix/aio-libs:matrix.org?label=Discuss%20on%20Matrix%20at%20%23aio-libs%3Amatrix.org&logo=matrix&server_fqdn=matrix.org&style=flat
    :target: https://matrix.to/#/%23aio-libs:matrix.org
-   :alt: Matrix Room 148 #aio-libs:matrix.org
+   :alt: Matrix Room — #aio-libs:matrix.org
 
 .. image:: https://img.shields.io/matrix/aio-libs-space:matrix.org?label=Discuss%20on%20Matrix%20at%20%23aio-libs-space%3Amatrix.org&logo=matrix&server_fqdn=matrix.org&style=flat
    :target: https://matrix.to/#/%23aio-libs-space:matrix.org
-   :alt: Matrix Space 148 #aio-libs-space:matrix.org
+   :alt: Matrix Space — #aio-libs-space:matrix.org
 
 Installation
 ------------

--- a/README.rst
+++ b/README.rst
@@ -16,11 +16,11 @@ async-lru
 
 .. image:: https://img.shields.io/matrix/aio-libs:matrix.org?label=Discuss%20on%20Matrix%20at%20%23aio-libs%3Amatrix.org&logo=matrix&server_fqdn=matrix.org&style=flat
    :target: https://matrix.to/#/%23aio-libs:matrix.org
-   :alt: Matrix Room — #aio-libs:matrix.org
+   :alt: Matrix Room 148 #aio-libs:matrix.org
 
 .. image:: https://img.shields.io/matrix/aio-libs-space:matrix.org?label=Discuss%20on%20Matrix%20at%20%23aio-libs-space%3Amatrix.org&logo=matrix&server_fqdn=matrix.org&style=flat
    :target: https://matrix.to/#/%23aio-libs-space:matrix.org
-   :alt: Matrix Space — #aio-libs-space:matrix.org
+   :alt: Matrix Space 148 #aio-libs-space:matrix.org
 
 Installation
 ------------
@@ -77,6 +77,18 @@ parameter (off by default):
     async def func(arg):
         return arg * 2
 
+To prevent thundering herd issues when many cache entries expire simultaneously,
+you can add ``jitter`` to randomize the TTL for each entry:
+
+.. code-block:: python
+
+    @alru_cache(ttl=3600, jitter=1800)
+    async def func(arg):
+        return arg * 2
+
+With ``ttl=3600, jitter=1800``, each cache entry will have a random TTL
+between 3600 and 5400 seconds, spreading out invalidations over time.
+
 
 The library supports explicit invalidation for specific function call by
 `cache_invalidate()`:
@@ -91,6 +103,53 @@ The library supports explicit invalidation for specific function call by
 
 The method returns `True` if corresponding arguments set was cached already, `False`
 otherwise.
+
+Limitations
+-----------
+
+**Event Loop Affinity**: ``alru_cache`` enforces that a cache instance is used with only
+one event loop. If you attempt to use a cached function from a different event loop than
+where it was first called, a ``RuntimeError`` will be raised:
+
+.. code-block:: text
+
+    RuntimeError: alru_cache is not safe to use across event loops: this cache
+    instance was first used with a different event loop.
+    Use separate cache instances per event loop.
+
+For typical asyncio applications using a single event loop, this is automatic and requires
+no configuration. If your application uses multiple event loops, create separate cache
+instances per loop:
+
+.. code-block:: python
+
+    import threading
+
+    _local = threading.local()
+
+    def get_cached_fetcher():
+        if not hasattr(_local, 'fetcher'):
+            @alru_cache(maxsize=100)
+            async def fetch_data(key):
+                ...
+            _local.fetcher = fetch_data
+        return _local.fetcher
+
+You can also reuse the logic of an already decorated function in a new loop by accessing ``__wrapped__``:
+
+.. code-block:: python
+
+    @alru_cache(maxsize=32)
+    async def my_task(x):
+        ...
+
+    # In Loop 1:
+    # my_task() uses the default global cache instance
+
+    # In Loop 2 (or a new thread):
+    # Create a fresh cache instance for the same logic
+    cached_task_loop2 = alru_cache(maxsize=32)(my_task.__wrapped__)
+    await cached_task_loop2(x)
 
 Benchmarks
 ----------

--- a/async_lru/__init__.py
+++ b/async_lru/__init__.py
@@ -4,8 +4,9 @@ import functools
 import inspect
 import logging
 import os
+import random
 import sys
-from asyncio.coroutines import _is_coroutine  # type: ignore[attr-defined]
+from functools import _CacheInfo, _make_key, partial, partialmethod
 from typing import (
     Any,
     Callable,
@@ -35,19 +36,19 @@ if sys.version_info < (3, 14):
     from asyncio.coroutines import _is_coroutine  # type: ignore[attr-defined]
 
 
-__version__ = "2.0.5"
+__version__ = "2.1.0"
 
 __all__ = ("alru_cache",)
 
-
 ALLOW_SYNC: Final = os.environ.get("ASYNC_LRU_ALLOW_SYNC")
 """When set, allows wrapping sync callables by bypassing coroutine checks."""
+
 
 _T = TypeVar("_T")
 _R = TypeVar("_R")
 _Coro = Coroutine[Any, Any, _R]
 _CB = Callable[..., _Coro[_R]]
-_CBP = Union[_CB[_R], functools.partial[_Coro[_R]], functools.partialmethod[_Coro[_R]]]
+_CBP = Union[_CB[_R], "partial[_Coro[_R]]", "partialmethod[_Coro[_R]]"]
 
 _PYTHON_GTE_312: Final = sys.version_info >= (3, 12)
 
@@ -87,7 +88,6 @@ class _CacheItem(Generic[_R]):
 
 
 @final
-#@mypyc_attr(native_class=False)
 class _LRUCacheWrapper(Generic[_R]):
     def __init__(
         self,
@@ -95,6 +95,7 @@ class _LRUCacheWrapper(Generic[_R]):
         maxsize: Optional[int],
         typed: bool,
         ttl: Optional[float],
+        jitter: Optional[float],
     ) -> None:
         try:
             self.__module__: Final = fn.__module__
@@ -117,7 +118,7 @@ class _LRUCacheWrapper(Generic[_R]):
         except AttributeError:
             pass
         try:
-            self.__dict__ = dict(fn.__dict__)
+            self.__dict__.update(fn.__dict__)
         except AttributeError:
             pass
         # set __wrapped__ last so we don't inadvertently copy it
@@ -128,14 +129,17 @@ class _LRUCacheWrapper(Generic[_R]):
         self.__maxsize: Final = maxsize
         self.__typed: Final = typed
         self.__ttl: Final = ttl
+        self.__jitter: Final = jitter
         self.__cache: Final[OrderedDict[Hashable, _CacheItem[_R]]] = OrderedDict()
         self.__closed = False
         self.__hits = 0
         self.__misses = 0
+        self.__first_loop: Optional[asyncio.AbstractEventLoop] = None
 
     @property
     def __tasks(self) -> List["asyncio.Task[_R]"]:
-        # NOTE: I don't think we need to form a set first here but not too sure we want it for guarantees
+        # NOTE: I don't think we need to form a set first here but not
+        # too sure we want it for guarantees
         return list(
             {
                 cache_item.task
@@ -143,6 +147,16 @@ class _LRUCacheWrapper(Generic[_R]):
                 if not cache_item.task.done()
             }
         )
+
+    def _check_loop(self, loop: asyncio.AbstractEventLoop) -> None:
+        if self.__first_loop is None:
+            self.__first_loop = loop
+        elif self.__first_loop is not loop:
+            raise RuntimeError(
+                "alru_cache is not safe to use across event loops: this cache "
+                "instance was first used with a different event loop. "
+                "Use separate cache instances per event loop."
+            )
 
     def cache_invalidate(self, /, *args: Hashable, **kwargs: Any) -> bool:
         key = _make_key(args, kwargs, self.__typed)
@@ -164,6 +178,8 @@ class _LRUCacheWrapper(Generic[_R]):
         self.__cache.clear()
 
     async def cache_close(self, *, wait: bool = False) -> None:
+        loop = get_running_loop()
+        self._check_loop(loop)
         self.__closed = True
 
         tasks = self.__tasks
@@ -171,14 +187,13 @@ class _LRUCacheWrapper(Generic[_R]):
             return
 
         if not wait:
-            cancel_msg = f"{self} is closed"
             for task in tasks:
                 if not task.done():
-                    task.cancel(cancel_msg)
+                    task.cancel()
 
         await gather(*tasks, return_exceptions=True)
 
-    def cache_info(self) -> functools._CacheInfo:
+    def cache_info(self) -> _CacheInfo:
         return _CacheInfo(
             self.__hits,
             self.__misses,
@@ -209,13 +224,14 @@ class _LRUCacheWrapper(Generic[_R]):
             self.__cache.pop(key, None)
             return
 
-        cache = self.__cache
-        cache_item = cache.get(key)
-        ttl = self.__ttl
-        if ttl is not None and cache_item is not None:
-            loop = asyncio.get_running_loop()
+        cache_item = self.__cache.get(key)
+        if self.__ttl is not None and cache_item is not None:
+            effective_ttl = self.__ttl
+            if self.__jitter is not None:
+                effective_ttl += random.uniform(0, self.__jitter)
+            loop = get_running_loop()
             cache_item.later_call = loop.call_later(
-                ttl, cache.pop, key, None
+                effective_ttl, self.__cache.pop, key, None
             )
 
     async def _shield_and_handle_cancelled_error(
@@ -224,13 +240,13 @@ class _LRUCacheWrapper(Generic[_R]):
         task = cache_item.task
         try:
             # All waiters await the same shielded task.
-            return await asyncio.shield(task)
+            return await shield(task)
         except asyncio.CancelledError:
             # If this is the last waiter and the underlying task is not done,
             # cancel the underlying task and remove the cache entry.
             if cache_item.waiters == 1 and not task.done():
                 cache_item.cancel()  # Cancel TTL expiration
-                task.cancel(f"alru_cache {task} has no more waiters")  # Cancel the running coroutine
+                task.cancel()  # Cancel the running coroutine
                 self.__cache.pop(key, None)  # Remove from cache
             raise
         finally:
@@ -238,40 +254,35 @@ class _LRUCacheWrapper(Generic[_R]):
             cache_item.waiters -= 1
 
     async def __call__(self, /, *fn_args: Any, **fn_kwargs: Any) -> _R:
-        task: asyncio.Task[_R]
-
         if self.__closed:
             raise RuntimeError(f"alru_cache is closed for {self}")
 
         loop = get_running_loop()
+        self._check_loop(loop)
 
         key = _make_key(fn_args, fn_kwargs, self.__typed)
 
-        cache = self.__cache
-
-        cache_item = cache.get(key)
+        cache_item = self.__cache.get(key)
 
         if cache_item is not None:
             self._cache_hit(key)
-            task = cache_item.task
             if not cache_item.task.done():
                 # Each logical waiter increments waiters on entry.
                 cache_item.waiters += 1
                 return await self._shield_and_handle_cancelled_error(cache_item, key)
 
             # If the task is already done, just return the result.
-            return task.result()
+            return cache_item.task.result()
 
         coro = self.__wrapped__(*fn_args, **fn_kwargs)
-        task = loop.create_task(coro)
+        task: asyncio.Task[_R] = loop.create_task(coro)
         task.add_done_callback(partial(self._task_done_callback, key))
 
         cache_item = _CacheItem(task, None, 1)
-        cache[key] = cache_item
+        self.__cache[key] = cache_item
 
-        maxsize = self.__maxsize
-        if maxsize is not None and len(cache) > maxsize:
-            dropped_key, dropped_cache_item = cache.popitem(last=False)
+        if self.__maxsize is not None and len(self.__cache) > self.__maxsize:
+            dropped_key, dropped_cache_item = self.__cache.popitem(last=False)
             dropped_cache_item.cancel()
 
         self._cache_miss(key)
@@ -288,7 +299,6 @@ class _LRUCacheWrapper(Generic[_R]):
 
 
 @final
-#@mypyc_attr(native_class=False)
 class _LRUCacheWrapperInstanceMethod(Generic[_R, _T]):
     def __init__(
         self,
@@ -316,7 +326,7 @@ class _LRUCacheWrapperInstanceMethod(Generic[_R, _T]):
         except AttributeError:
             pass
         try:
-            self.__dict__ = dict(wrapper.__dict__)
+            self.__dict__.update(wrapper.__dict__)
         except AttributeError:
             pass
         # set __wrapped__ last so we don't inadvertently copy it
@@ -338,7 +348,7 @@ class _LRUCacheWrapperInstanceMethod(Generic[_R, _T]):
     ) -> None:
         await self.__wrapper.cache_close()
 
-    def cache_info(self) -> functools._CacheInfo:
+    def cache_info(self) -> _CacheInfo:
         return self.__wrapper.cache_info()
 
     def cache_parameters(self) -> _CacheParameters:
@@ -352,7 +362,13 @@ def _make_wrapper(
     maxsize: Optional[int],
     typed: bool,
     ttl: Optional[float] = None,
+    jitter: Optional[float] = None,
 ) -> Callable[[_CBP[_R]], _LRUCacheWrapper[_R]]:
+    if jitter is not None and ttl is None:
+        raise ValueError("jitter requires ttl to be set")
+    if jitter is not None and jitter < 0:
+        raise ValueError("jitter must be non-negative")
+
     def wrapper(fn: _CBP[_R]) -> _LRUCacheWrapper[_R]:
         origin = fn
 
@@ -362,16 +378,26 @@ def _make_wrapper(
         if not asyncio.iscoroutinefunction(origin) and not ALLOW_SYNC:
             raise RuntimeError(f"Coroutine function is required, got {fn!r}")
 
-        # functools.partialmethod support
         if hasattr(fn, "_make_unbound_method"):
             fn = fn._make_unbound_method()
 
-        wrapper = _LRUCacheWrapper(cast(_CB[_R], fn), maxsize, typed, ttl)  # type: ignore [redundant-cast]
+        wrapper = _LRUCacheWrapper(cast(_CB[_R], fn), maxsize, typed, ttl, jitter)
         if _PYTHON_GTE_312:
-            wrapper = markcoroutinefunction(wrapper)  # type: ignore [misc]
-        return wrapper  # type: ignore [no-any-return]
+            wrapper = markcoroutinefunction(wrapper)
+        return wrapper
 
     return wrapper
+
+
+@overload
+def alru_cache(
+    maxsize: Optional[int] = 128,
+    typed: bool = False,
+    *,
+    ttl: Optional[float] = None,
+    jitter: Optional[float] = None,
+) -> Callable[[_CBP[_R]], _LRUCacheWrapper[_R]]:
+    ...
 
 
 @overload
@@ -382,28 +408,19 @@ def alru_cache(
     ...
 
 
-@overload
-def alru_cache(
-    maxsize: Optional[int] = 128,
-    typed: bool = False,
-    *,
-    ttl: Optional[float] = None,
-) -> Callable[[_CBP[_R]], _LRUCacheWrapper[_R]]:
-    ...
-
-
 def alru_cache(
     maxsize: Union[Optional[int], _CBP[_R]] = 128,
     typed: bool = False,
     *,
     ttl: Optional[float] = None,
+    jitter: Optional[float] = None,
 ) -> Union[Callable[[_CBP[_R]], _LRUCacheWrapper[_R]], _LRUCacheWrapper[_R]]:
     if maxsize is None or isinstance(maxsize, int):
-        return _make_wrapper(maxsize, typed, ttl)
+        return _make_wrapper(maxsize, typed, ttl, jitter)
     else:
         fn = cast(_CB[_R], maxsize)
 
         if callable(fn) or hasattr(fn, "_make_unbound_method"):
-            return _make_wrapper(128, False, None)(fn)
+            return _make_wrapper(128, False, None, None)(fn)
 
         raise NotImplementedError(f"{fn!r} decorating is not supported")

--- a/benchmark.py
+++ b/benchmark.py
@@ -17,10 +17,17 @@ else:
 
 @pytest.fixture
 def loop():
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    yield loop
-    loop.close()
+    # Save current loop to restore after the test
+    try:
+        old_loop = asyncio.get_running_loop()
+    except RuntimeError:
+        old_loop = None
+    new_loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(new_loop)
+    yield new_loop
+    new_loop.close()
+    if old_loop is not None:
+        asyncio.set_event_loop(old_loop)
 
 
 @pytest.fixture
@@ -38,43 +45,73 @@ def run_loop(loop):
 
 
 # Bounded cache (LRU)
-@alru_cache(maxsize=128)
-async def cached_func(x):
+async def _cached_func(x):
     return x
 
 
-@alru_cache(maxsize=16, ttl=0.01)
-async def cached_func_ttl(x):
+def create_cached_func():
+    return alru_cache(maxsize=128)(_cached_func)
+
+
+async def _cached_func_ttl(x):
     return x
+
+
+def create_cached_func_ttl():
+    return alru_cache(maxsize=16, ttl=0.01)(_cached_func_ttl)
 
 
 # Unbounded cache (no maxsize)
-@alru_cache()
-async def cached_func_unbounded(x):
+async def _cached_func_unbounded(x):
     return x
 
 
-@alru_cache(ttl=0.01)
-async def cached_func_unbounded_ttl(x):
+def create_cached_func_unbounded():
+    return alru_cache()(_cached_func_unbounded)
+
+
+async def _cached_func_unbounded_ttl(x):
     return x
 
 
-class Methods:
-    @alru_cache(maxsize=128)
-    async def cached_meth(self, x):
-        return x
+def create_cached_func_unbounded_ttl():
+    return alru_cache(ttl=0.01)(_cached_func_unbounded_ttl)
 
-    @alru_cache(maxsize=16, ttl=0.01)
-    async def cached_meth_ttl(self, x):
-        return x
 
-    @alru_cache()
-    async def cached_meth_unbounded(self, x):
-        return x
+def create_cached_meth():
+    class MethodsInstance:
+        @alru_cache(maxsize=128)
+        async def cached_meth(self, x):
+            return x
 
-    @alru_cache(ttl=0.01)
-    async def cached_meth_unbounded_ttl(self, x):
-        return x
+    return MethodsInstance().cached_meth
+
+
+def create_cached_meth_ttl():
+    class MethodsInstance:
+        @alru_cache(maxsize=16, ttl=0.01)
+        async def cached_meth_ttl(self, x):
+            return x
+
+    return MethodsInstance().cached_meth_ttl
+
+
+def create_cached_meth_unbounded():
+    class MethodsInstance:
+        @alru_cache()
+        async def cached_meth_unbounded(self, x):
+            return x
+
+    return MethodsInstance().cached_meth_unbounded
+
+
+def create_cached_meth_unbounded_ttl():
+    class MethodsInstance:
+        @alru_cache(ttl=0.01)
+        async def cached_meth_unbounded_ttl(self, x):
+            return x
+
+    return MethodsInstance().cached_meth_unbounded_ttl
 
 
 async def uncached_func(x):
@@ -82,10 +119,10 @@ async def uncached_func(x):
 
 
 funcs_no_ttl = [
-    cached_func,
-    cached_func_unbounded,
-    Methods.cached_meth,
-    Methods.cached_meth_unbounded,
+    create_cached_func,
+    create_cached_func_unbounded,
+    create_cached_meth,
+    create_cached_meth_unbounded,
 ]
 no_ttl_ids = [
     "func-bounded",
@@ -95,10 +132,10 @@ no_ttl_ids = [
 ]
 
 funcs_ttl = [
-    cached_func_ttl,
-    cached_func_unbounded_ttl,
-    Methods.cached_meth_ttl,
-    Methods.cached_meth_unbounded_ttl,
+    create_cached_func_ttl,
+    create_cached_func_unbounded_ttl,
+    create_cached_meth_ttl,
+    create_cached_meth_unbounded_ttl,
 ]
 ttl_ids = [
     "func-bounded-ttl",
@@ -111,13 +148,13 @@ all_funcs = [*funcs_no_ttl, *funcs_ttl]
 all_ids = [*no_ttl_ids, *ttl_ids]
 
 
-@pytest.mark.parametrize("func", all_funcs, ids=all_ids)
+@pytest.mark.parametrize("factory", all_funcs, ids=all_ids)
 def test_cache_hit_benchmark(
     benchmark: BenchmarkFixture,
     run_loop: Callable[..., Any],
-    func: _LRUCacheWrapper[Any],
+    factory: Callable[[], _LRUCacheWrapper[Any]],
 ) -> None:
-    # Populate cache
+    func = factory()
     keys = list(range(10))
     for key in keys:
         run_loop(func, key)
@@ -130,12 +167,13 @@ def test_cache_hit_benchmark(
     benchmark(run_loop, run)
 
 
-@pytest.mark.parametrize("func", all_funcs, ids=all_ids)
+@pytest.mark.parametrize("factory", all_funcs, ids=all_ids)
 def test_cache_miss_benchmark(
     benchmark: BenchmarkFixture,
     run_loop: Callable[..., Any],
-    func: _LRUCacheWrapper[Any],
+    factory: Callable[[], _LRUCacheWrapper[Any]],
 ) -> None:
+    func = factory()
     func.cache_clear()
     # Use 2048 objects (16x maxsize=128) to force evictions and measure actual misses.
     unique_objects = [object() for _ in range(2048)]
@@ -147,37 +185,39 @@ def test_cache_miss_benchmark(
     benchmark(run_loop, run)
 
 
-@pytest.mark.parametrize("func", all_funcs, ids=all_ids)
+@pytest.mark.parametrize("factory", all_funcs, ids=all_ids)
 def test_cache_clear_benchmark(
     benchmark: BenchmarkFixture,
     run_loop: Callable[..., Any],
-    func: _LRUCacheWrapper[Any],
+    factory: Callable[[], _LRUCacheWrapper[Any]],
 ) -> None:
+    func = factory()
     for i in range(100):
         run_loop(func, i)
 
     benchmark(func.cache_clear)
 
 
-@pytest.mark.parametrize("func_ttl", funcs_ttl, ids=ttl_ids)
+@pytest.mark.parametrize("factory", funcs_ttl, ids=ttl_ids)
 def test_cache_ttl_expiry_benchmark(
     benchmark: BenchmarkFixture,
     run_loop: Callable[..., Any],
-    func_ttl: _LRUCacheWrapper[Any],
+    factory: Callable[[], _LRUCacheWrapper[Any]],
 ) -> None:
+    func_ttl = factory()
     run_loop(func_ttl, 99)
     run_loop(asyncio.sleep, 0.02)
 
     benchmark(run_loop, func_ttl, 99)
 
 
-@pytest.mark.parametrize("func", all_funcs, ids=all_ids)
+@pytest.mark.parametrize("factory", all_funcs, ids=all_ids)
 def test_cache_invalidate_benchmark(
     benchmark: BenchmarkFixture,
     run_loop: Callable[..., Any],
-    func: _LRUCacheWrapper[Any],
+    factory: Callable[[], _LRUCacheWrapper[Any]],
 ) -> None:
-    # Populate cache
+    func = factory()
     keys = list(range(123, 321))
     for i in keys:
         run_loop(func, i)
@@ -190,13 +230,13 @@ def test_cache_invalidate_benchmark(
             invalidate(i)
 
 
-@pytest.mark.parametrize("func", all_funcs, ids=all_ids)
+@pytest.mark.parametrize("factory", all_funcs, ids=all_ids)
 def test_cache_info_benchmark(
     benchmark: BenchmarkFixture,
     run_loop: Callable[..., Any],
-    func: _LRUCacheWrapper[Any],
+    factory: Callable[[], _LRUCacheWrapper[Any]],
 ) -> None:
-    # Populate cache
+    func = factory()
     keys = list(range(1000))
     for i in keys:
         run_loop(func, i)
@@ -209,13 +249,13 @@ def test_cache_info_benchmark(
             cache_info()
 
 
-@pytest.mark.parametrize("func", all_funcs, ids=all_ids)
+@pytest.mark.parametrize("factory", all_funcs, ids=all_ids)
 def test_concurrent_cache_hit_benchmark(
     benchmark: BenchmarkFixture,
     run_loop: Callable[..., Any],
-    func: _LRUCacheWrapper[Any],
+    factory: Callable[[], _LRUCacheWrapper[Any]],
 ) -> None:
-    # Populate cache
+    func = factory()
     keys = list(range(600, 700))
     for key in keys:
         run_loop(func, key)
@@ -223,7 +263,7 @@ def test_concurrent_cache_hit_benchmark(
     async def gather_coros():
         gather = asyncio.gather
         for _ in range(10):
-            return await gather(*map(func, keys))
+            await gather(*map(func, keys))
 
     benchmark(run_loop, gather_coros)
 
@@ -231,15 +271,15 @@ def test_concurrent_cache_hit_benchmark(
 def test_cache_fill_eviction_benchmark(
     benchmark: BenchmarkFixture, run_loop: Callable[..., Any]
 ) -> None:
-    # Populate cache
+    func = create_cached_func()
     for i in range(-128, 0):
-        run_loop(cached_func, i)
+        run_loop(func, i)
 
     keys = list(range(5000))
 
     async def fill():
         for k in keys:
-            await cached_func(k)
+            await func(k)
 
     benchmark(run_loop, fill)
 
@@ -253,20 +293,20 @@ def test_cache_fill_eviction_benchmark(
 # The relevant internal methods do not exist on _LRUCacheWrapperInstanceMethod,
 # so we can skip methods for this part of the benchmark suite.
 # We also skip wrappers with ttl because it raises KeyError.
-only_funcs_no_ttl = all_funcs[:2]
-func_ids_no_ttl = all_ids[:2]
+only_funcs_no_ttl = funcs_no_ttl[:2]
+func_ids_no_ttl = no_ttl_ids[:2]
 
 
-@pytest.mark.parametrize("func", only_funcs_no_ttl, ids=func_ids_no_ttl)
+@pytest.mark.parametrize("factory", only_funcs_no_ttl, ids=func_ids_no_ttl)
 def test_internal_cache_hit_microbenchmark(
     benchmark: BenchmarkFixture,
     run_loop: Callable[..., Any],
-    func: _LRUCacheWrapper[Any],
+    factory: Callable[[], _LRUCacheWrapper[Any]],
 ) -> None:
     """Directly benchmark _cache_hit (internal, sync) using parameterized funcs."""
+    func = factory()
     cache_hit = func._cache_hit
 
-    # Populate cache
     keys = list(range(128))
     for i in keys:
         run_loop(func, i)
@@ -277,11 +317,12 @@ def test_internal_cache_hit_microbenchmark(
             cache_hit(i)
 
 
-@pytest.mark.parametrize("func", only_funcs_no_ttl, ids=func_ids_no_ttl)
+@pytest.mark.parametrize("factory", only_funcs_no_ttl, ids=func_ids_no_ttl)
 def test_internal_cache_miss_microbenchmark(
-    benchmark: BenchmarkFixture, func: _LRUCacheWrapper[Any]
+    benchmark: BenchmarkFixture, factory: Callable[[], _LRUCacheWrapper[Any]]
 ) -> None:
     """Directly benchmark _cache_miss (internal, sync) using parameterized funcs."""
+    func = factory()
     cache_miss = func._cache_miss
 
     @benchmark
@@ -290,17 +331,17 @@ def test_internal_cache_miss_microbenchmark(
             cache_miss(i)
 
 
-@pytest.mark.parametrize("func", only_funcs_no_ttl, ids=func_ids_no_ttl)
+@pytest.mark.parametrize("factory", only_funcs_no_ttl, ids=func_ids_no_ttl)
 @pytest.mark.parametrize("task_state", ["finished", "cancelled", "exception"])
 def test_internal_task_done_callback_microbenchmark(
     benchmark: BenchmarkFixture,
     loop: asyncio.BaseEventLoop,
-    func: _LRUCacheWrapper[Any],
+    factory: Callable[[], _LRUCacheWrapper[Any]],
     task_state: str,
 ) -> None:
     """Directly benchmark _task_done_callback (internal, sync) using parameterized funcs and task states."""
+    func = factory()
 
-    # Create a dummy coroutine and task
     async def dummy_coro():
         if task_state == "exception":
             raise ValueError("test exception")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 -e .
 -r requirements-test.txt
 
-coverage==7.13.0
+coverage==7.13.4
 pytest-cov==7.0.0

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -1,14 +1,16 @@
 import asyncio
+import gc
+import logging
 from functools import partial
 from unittest import mock
 
 import pytest
 
-from async_lru import _LRUCacheWrapper
+from async_lru import _CacheItem, _LRUCacheWrapper
 
 
 async def test_done_callback_cancelled() -> None:
-    wrapped = _LRUCacheWrapper(mock.ANY, None, False, None)
+    wrapped = _LRUCacheWrapper(mock.ANY, None, False, None, None)
     loop = asyncio.get_running_loop()
     task = loop.create_future()
 
@@ -24,7 +26,7 @@ async def test_done_callback_cancelled() -> None:
 
 
 async def test_done_callback_exception() -> None:
-    wrapped = _LRUCacheWrapper(mock.ANY, None, False, None)
+    wrapped = _LRUCacheWrapper(mock.ANY, None, False, None, None)
     loop = asyncio.get_running_loop()
     task = loop.create_future()
 
@@ -41,8 +43,44 @@ async def test_done_callback_exception() -> None:
     assert task not in wrapped._LRUCacheWrapper__tasks  # type: ignore[attr-defined]
 
 
+async def test_done_callback_exception_logs(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.ERROR, logger="asyncio")
+
+    wrapped = _LRUCacheWrapper(mock.ANY, None, False, None, None)
+    loop = asyncio.get_running_loop()
+
+    async def boom() -> None:
+        await asyncio.sleep(0)
+        raise RuntimeError("boom")
+
+    key = object()
+    task = loop.create_task(boom())
+    wrapped._LRUCacheWrapper__cache[key] = _CacheItem(task, None, 1)  # type: ignore[attr-defined]
+    task.add_done_callback(partial(wrapped._task_done_callback, key))
+
+    while not task.done():
+        await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert key not in wrapped._LRUCacheWrapper__cache  # type: ignore[attr-defined]
+    # asyncio disables logging when exception() is called; keep logging enabled.
+    assert task._log_traceback
+
+    caplog.clear()
+
+    del task  # Remove reference so task get garbage collected.
+    for _ in range(5):  # pragma: no branch
+        gc.collect()
+        await asyncio.sleep(0)
+        if "Task exception was never retrieved" in caplog.text:  # pragma: no branch
+            break
+
+    assert "Task exception was never retrieved" in caplog.text
+    assert "RuntimeError: boom" in caplog.text
+
+
 async def test_cache_invalidate_typed() -> None:
-    wrapped = _LRUCacheWrapper(mock.AsyncMock(return_value=1), None, True, None)
+    wrapped = _LRUCacheWrapper(mock.AsyncMock(return_value=1), None, True, None, None)
 
     from_cache = wrapped.cache_invalidate(1, a=1)
 
@@ -67,7 +105,7 @@ async def test_cache_invalidate_typed() -> None:
 
 
 async def test_cache_invalidate_not_typed() -> None:
-    wrapped = _LRUCacheWrapper(mock.AsyncMock(return_value=1), None, False, None)
+    wrapped = _LRUCacheWrapper(mock.AsyncMock(return_value=1), None, False, None, None)
 
     from_cache = wrapped.cache_invalidate(1, a=1)
     assert not from_cache
@@ -88,7 +126,7 @@ async def test_cache_invalidate_not_typed() -> None:
 
 
 async def test_cache_clear() -> None:
-    wrapped = _LRUCacheWrapper(mock.AsyncMock(return_value=1), None, True, None)
+    wrapped = _LRUCacheWrapper(mock.AsyncMock(return_value=1), None, True, None, None)
 
     await wrapped(123)
 
@@ -112,7 +150,7 @@ async def test_cache_clear() -> None:
 
 
 def test_cache_info() -> None:
-    wrapped = _LRUCacheWrapper(mock.ANY, 3, True, None)
+    wrapped = _LRUCacheWrapper(mock.ANY, 3, True, None, None)
 
     assert (0, 0, 3, 0) == wrapped.cache_info()
 
@@ -128,7 +166,7 @@ def test_cache_info() -> None:
 
 
 async def test_cache_hit() -> None:
-    wrapped = _LRUCacheWrapper(mock.AsyncMock(return_value=1), None, True, None)
+    wrapped = _LRUCacheWrapper(mock.AsyncMock(return_value=1), None, True, None, None)
     await wrapped(1)
     assert wrapped.cache_info().hits == 0
     assert wrapped.cache_info().misses == 1
@@ -141,7 +179,7 @@ async def test_cache_hit() -> None:
 
 
 async def test_cache_miss() -> None:
-    wrapped = _LRUCacheWrapper(mock.AsyncMock(return_value=1), None, True, None)
+    wrapped = _LRUCacheWrapper(mock.AsyncMock(return_value=1), None, True, None, None)
     await wrapped(1)
     assert wrapped.cache_info().hits == 0
     assert wrapped.cache_info().misses == 1
@@ -154,7 +192,7 @@ async def test_cache_miss() -> None:
 
 
 async def test_forbid_call_closed() -> None:
-    wrapped = _LRUCacheWrapper(mock.AsyncMock(return_value=1), None, True, None)
+    wrapped = _LRUCacheWrapper(mock.AsyncMock(return_value=1), None, True, None, None)
     wrapped._LRUCacheWrapper__closed = True  # type: ignore[attr-defined]
     with pytest.raises(RuntimeError):
         await wrapped(123)

--- a/tests/test_readme_examples.py
+++ b/tests/test_readme_examples.py
@@ -1,0 +1,53 @@
+import asyncio
+import threading
+from typing import Any
+
+from async_lru import alru_cache
+
+
+def test_readme_example_per_thread_caching() -> None:
+    """Test per-thread caching pattern from README to avoid thread-safety issues."""
+    _local = threading.local()
+
+    def get_cached_fetcher() -> Any:
+        if not hasattr(_local, "fetcher"):
+
+            @alru_cache(maxsize=100)
+            async def fetch_data(key: str) -> str:
+                return f"data_{key}"
+
+            _local.fetcher = fetch_data
+        return _local.fetcher
+
+    async def worker() -> tuple[str, Any]:
+        fetcher = get_cached_fetcher()
+        # Call again to ensure the pattern handles the "already exists" case
+        fetcher_retry = get_cached_fetcher()
+        assert fetcher is fetcher_retry
+
+        result = await fetcher("some_key")
+        return result, fetcher.cache_info()
+
+    def thread_worker(results: list[tuple[str, Any]]) -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            result = loop.run_until_complete(worker())
+            results.append(result)
+        finally:
+            loop.close()
+
+    results: list[tuple[str, Any]] = []
+    threads = [
+        threading.Thread(target=thread_worker, args=(results,)) for _ in range(3)
+    ]
+
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(results) == 3
+    for result, cache_info in results:
+        assert result == "data_some_key"
+        assert cache_info.misses == 1

--- a/tests/test_thread_safety.py
+++ b/tests/test_thread_safety.py
@@ -1,0 +1,102 @@
+import asyncio
+
+from async_lru import alru_cache
+
+
+def test_cross_loop_access_raises_error() -> None:
+    @alru_cache(maxsize=100)
+    async def cached_func(key: str) -> str:
+        return f"data_{key}"
+
+    loop1 = asyncio.new_event_loop()
+    loop1.run_until_complete(cached_func("test"))
+    loop1.close()
+
+    loop2 = asyncio.new_event_loop()
+    error_raised = False
+    error_message = ""
+    try:
+        loop2.run_until_complete(cached_func("test"))
+    except RuntimeError as e:
+        error_raised = True
+        error_message = str(e)
+    finally:
+        loop2.close()
+
+    assert error_raised, "RuntimeError should be raised for cross-loop access"
+    assert "event loop" in error_message.lower()
+
+
+def test_same_loop_access_works() -> None:
+    @alru_cache(maxsize=100)
+    async def cached_func(key: str) -> str:
+        return f"data_{key}"
+
+    async def run_test() -> list[str]:
+        results = []
+        results.append(await cached_func("a"))
+        results.append(await cached_func("b"))
+        results.append(await cached_func("a"))
+        return results
+
+    loop = asyncio.new_event_loop()
+    results = loop.run_until_complete(run_test())
+    loop.close()
+
+    assert results == ["data_a", "data_b", "data_a"]
+    assert cached_func.cache_info().hits == 1
+
+
+def test_cross_loop_cache_close_raises_error() -> None:
+    @alru_cache(maxsize=100)
+    async def cached_func(key: str) -> str:
+        return f"data_{key}"
+
+    loop1 = asyncio.new_event_loop()
+    loop1.run_until_complete(cached_func("test"))
+    loop1.close()
+
+    loop2 = asyncio.new_event_loop()
+    error_raised = False
+    try:
+        loop2.run_until_complete(cached_func.cache_close())
+    except RuntimeError:
+        error_raised = True
+    finally:
+        loop2.close()
+
+    assert error_raised, "RuntimeError should be raised for cross-loop cache_close"
+
+
+def test_sync_methods_work_without_loop_check() -> None:
+    @alru_cache(maxsize=100)
+    async def cached_func(key: str) -> str:
+        return f"data_{key}"
+
+    loop1 = asyncio.new_event_loop()
+    loop1.run_until_complete(cached_func("test"))
+    loop1.close()
+
+    cached_func.cache_invalidate("test")
+    assert cached_func.cache_info().currsize == 0
+
+    cached_func.cache_clear()
+    assert cached_func.cache_info().currsize == 0
+
+
+def test_concurrent_same_loop_works() -> None:
+    @alru_cache(maxsize=100)
+    async def cached_func(key: str) -> str:
+        await asyncio.sleep(0.01)
+        return f"data_{key}"
+
+    async def run_concurrent() -> list[str]:
+        tasks = [cached_func("test") for _ in range(3)]
+        return await asyncio.gather(*tasks)
+
+    loop = asyncio.new_event_loop()
+    results = loop.run_until_complete(run_concurrent())
+    loop.close()
+
+    assert results == ["data_test"] * 3
+    assert cached_func.cache_info().hits == 2

--- a/tests/test_ttl.py
+++ b/tests/test_ttl.py
@@ -1,5 +1,8 @@
 import asyncio
 from typing import Callable
+from unittest import mock
+
+import pytest
 
 from async_lru import alru_cache
 
@@ -67,3 +70,42 @@ async def test_ttl_concurrent() -> None:
 
     results = await asyncio.gather(*(coro(i) for i in range(2)))
     assert results == list(range(2))
+
+
+async def test_ttl_with_jitter_basic(check_lru: Callable[..., None]) -> None:
+    with mock.patch("async_lru.random.uniform", return_value=0.1):
+
+        @alru_cache(maxsize=None, ttl=0.1, jitter=0.2)
+        async def coro(val: int) -> int:
+            return val
+
+        assert await coro(1) == 1
+        check_lru(coro, hits=0, misses=1, cache=1, tasks=0, maxsize=None)
+
+        await asyncio.sleep(0.15)
+        check_lru(coro, hits=0, misses=1, cache=1, tasks=0, maxsize=None)
+
+        await asyncio.sleep(0.1)
+        check_lru(coro, hits=0, misses=1, cache=0, tasks=0, maxsize=None)
+
+
+async def test_ttl_with_jitter_zero(check_lru: Callable[..., None]) -> None:
+    @alru_cache(maxsize=None, ttl=0.1, jitter=0)
+    async def coro(val: int) -> int:
+        return val
+
+    assert await coro(1) == 1
+    check_lru(coro, hits=0, misses=1, cache=1, tasks=0, maxsize=None)
+
+    await asyncio.sleep(0.15)
+    check_lru(coro, hits=0, misses=1, cache=0, tasks=0, maxsize=None)
+
+
+async def test_jitter_without_ttl_raises_error() -> None:
+    with pytest.raises(ValueError, match="jitter requires ttl to be set"):
+        alru_cache(maxsize=None, jitter=1.0)
+
+
+async def test_jitter_negative_raises_error() -> None:
+    with pytest.raises(ValueError, match="jitter must be non-negative"):
+        alru_cache(maxsize=None, ttl=1.0, jitter=-0.5)


### PR DESCRIPTION
Summary
- Sync upstream master changes for async-lru 2.1.0 and benchmark/test updates (replacement for PR #111).

Rationale
- Keep the fork aligned with upstream changes without merge conflicts.

Details
- `build/` artifacts were intentionally not updated due to MCP size limits; regenerate if needed.
- Tests: `/home/takopi/projects/faster-async-lru/.venv/bin/python -m pytest` fails on Python 3.14.3 with a DeprecationWarning from `asyncio.iscoroutinefunction` (45 failed, 13 passed, 1 error).