### PR TITLE
fix(cicd): scope CI paths and pin coverage

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -6,10 +6,34 @@ on:
       - master
       - '[0-9].[0-9]+'  # matches to backport branches, e.g. 3.6
     tags: [ 'v*' ]
+    paths:
+      - '**/*.py'
+      - 'tests/**'
+      - 'CHANGES.rst'
+      - 'MANIFEST.in'
+      - 'README.rst'
+      - 'pyproject.toml'
+      - 'setup.cfg'
+      - 'setup.py'
+      - 'tox.ini'
+      - 'requirements*.txt'
+      - '.github/workflows/ci-cd.yml'
   pull_request:
     branches:
       - master
       - '[0-9].[0-9]+'
+    paths:
+      - '**/*.py'
+      - 'tests/**'
+      - 'CHANGES.rst'
+      - 'MANIFEST.in'
+      - 'README.rst'
+      - 'pyproject.toml'
+      - 'setup.cfg'
+      - 'setup.py'
+      - 'tox.ini'
+      - 'requirements*.txt'
+      - '.github/workflows/ci-cd.yml'
 
 
 jobs:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 -e .
 -r requirements-test.txt
 
-coverage==7.13.0
+coverage==7.13.4
 pytest-cov==7.0.0


### PR DESCRIPTION
## Summary
Add CI workflow path filters for push/PR and bump the coverage pin to 7.13.4.

## Rationale
Keep CI focused on relevant changes and ensure coverage runs with a stable, up-to-date patch release.

## Details
- Add `paths` filters to `.github/workflows/ci-cd.yml` for push and pull_request.
- Bump `coverage` in `requirements.txt` from 7.13.0 to 7.13.4.

## Testing
- `/home/takopi/projects/faster-async-lru/.worktrees/master/.venv/bin/python -m pytest` (failed: DeprecationWarning from `asyncio.iscoroutinefunction` on Python 3.14; 37 failed, 10 passed).
- `PYTHONPATH=/tmp/async_lru_compiled /home/takopi/projects/faster-async-lru/.worktrees/master/.venv/bin/python -P -m pytest --import-mode=importlib` (failed at import: `AttributeError: attribute '__dict__' of 'type' objects is not writable` at `async_lru/__init__.py:78`; compiled extension could not load).
